### PR TITLE
Fix incorrect Substring logic causing launcher file imports to fail

### DIFF
--- a/FASTER/Views/SteamMods.xaml.cs
+++ b/FASTER/Views/SteamMods.xaml.cs
@@ -205,9 +205,7 @@ namespace FASTER.Views
             if (string.IsNullOrEmpty(modLine) || !modLine.Contains("data-type=\"Link\">http://steam") || !modLine.Contains("/?id=")) return;
 
             var link = modLine.Substring(modLine.IndexOf("http://steam", StringComparison.Ordinal));
-            link = Reverse(link);
-            link = link.Substring(link.IndexOf("epyt-atad", StringComparison.Ordinal) + 11);
-            link = Reverse(link);
+            link = link.Substring(0, link.Length - 4);
             try 
             { SteamMod.AddSteamMod(link, true); }
             catch
@@ -381,13 +379,6 @@ namespace FASTER.Views
                 catch
                 {  MessageBox.Show($"Could not open \"{url}\""); }
             }
-        }
-
-        private static string Reverse(string s)
-        {
-            char[] charArray = s.ToCharArray();
-            Array.Reverse(charArray);
-            return new string(charArray);
         }
     }
 }


### PR DESCRIPTION
I actually originally noticed this while fixing the buffer overflow issue you fixed in your previous release on the original FAST2 application. I hadn't even heard of FASTER until a few minutes ago, however here we are.

It looks like the same issue is happening in FASTER too; I'll just post what I posted over there as a pull request:


> As per my other PR, feel free to tell me if I've steered wrong here; but testing locally this Substring fix seems to strip the final </a> from the import link before it's passed on to SteamMod.AddSteamMod() which allows the file import to continue. Maybe the SteamAPI was changed at some point which broke the previous implementation, as it was stripping a majority of the IDs from the URLs.
> 
> I've tested this with my local exported HTML modset from the A3 client and all mods are pulled into the FAST2 Application just fine, though I'm aware there may be some edge cases I'm not thinking of.


Hopefully the fix works for you here too! I've checked it locally and it seems to import just fine on the `feature/Update-1.7` branch and on `master` (but obviously fails on some of the mods due to the int overflow).

I also removed the `Reverse()` function as cleanup, since this is the only place it was used anyway.

Also I appreciate you making the new repo; I was unable to make a PR on the other one you have due to github's restrictions on making forks of forks, since I have FAST2 already forked I was unable to fork the other repo, so this one is perfect!

