### PR TITLE
Fixes local mod loading issues

### DIFF
--- a/FASTER/Models/Functions.cs
+++ b/FASTER/Models/Functions.cs
@@ -105,16 +105,17 @@ namespace FASTER.Models
         public static string SafeName(string input, bool ignoreWhiteSpace = false, string replacement = "_")
         {
             input = input.Replace("@", "");
-            if (ignoreWhiteSpace)
+            if (ignoreWhiteSpace)//I'm assuming that for "ignore whitespace" we are meant to leave it untouched
             {
-                // input = Regex.Replace(input, "[^a-zA-Z0-9\-_\s]", replacement) >> "-" is allowed
-                input = Regex.Replace(input, @"[^a-zA-Z0-9_\s]", replacement);
-                input = input.Replace(replacement + replacement, replacement);
+                // Theese are the only characters not allowed on windows. Anything else works fine.
+                // Replacing characters that are legal in paths causes the local mods to stop being loaded properly.
+                // Ideally this whole operation should happen only on workshop mods.
+                input = Regex.Replace(input, "[<>:\"/\\|?*]", replacement);
+                input = input.Replace(replacement + replacement, replacement);//wtf is going on there?
                 return input;
             }
-            // input = Regex.Replace(input, "[^a-zA-Z0-9\-_]", replacement) >> "-" is allowed
-            input = Regex.Replace(input, "[^a-zA-Z0-9_]", replacement);
-            input = input.Replace(replacement + replacement, replacement);
+            input = Regex.Replace(input, "[<>:\"/\\|?*\\s]", replacement);
+            input = input.Replace(replacement + replacement, replacement);//wtf is going on there?
             return input;
         }
 

--- a/FASTER/Models/Functions.cs
+++ b/FASTER/Models/Functions.cs
@@ -104,17 +104,17 @@ namespace FASTER.Models
         // Takes any string and removes illegal characters
         public static string SafeName(string input, bool ignoreWhiteSpace = false, string replacement = "_")
         {
-            input = input.Replace("@", "");
+            //input = input.Replace("@", ""); Local mods can have full paths, this is useless and only breaks them.
             if (ignoreWhiteSpace)//I'm assuming that for "ignore whitespace" we are meant to leave it untouched
             {
                 // Theese are the only characters not allowed on windows. Anything else works fine.
                 // Replacing characters that are legal in paths causes the local mods to stop being loaded properly.
                 // Ideally this whole operation should happen only on workshop mods.
-                input = Regex.Replace(input, "[<>:\"/\\|?*]", replacement);
+                input = Regex.Replace(input, "[<>\"/\\|?*]", replacement);
                 input = input.Replace(replacement + replacement, replacement);//wtf is going on there?
                 return input;
             }
-            input = Regex.Replace(input, "[<>:\"/\\|?*\\s]", replacement);
+            input = Regex.Replace(input, "[<>\"/\\|?*\\s]", replacement);
             input = input.Replace(replacement + replacement, replacement);//wtf is going on there?
             return input;
         }

--- a/FASTER/ViewModel/ProfileViewModel.cs
+++ b/FASTER/ViewModel/ProfileViewModel.cs
@@ -178,8 +178,8 @@ namespace FASTER.ViewModel
             string config        = Path.Combine(Properties.Settings.Default.serverPath, "Servers", Profile.Id, "server_config.cfg");
             string basic         = Path.Combine(Properties.Settings.Default.serverPath, "Servers", Profile.Id, "server_basic.cfg");
 
-            string playerMods = string.Join(";", Profile.ProfileMods.Where(m => m.ClientSideChecked).Select(m => $"@{Functions.SafeName(m.Name)}"));
-            string serverMods = string.Join(";", Profile.ProfileMods.Where(m => m.ServerSideChecked).Select(m => $"@{Functions.SafeName(m.Name)}"));
+            string playerMods = string.Join(";", Profile.ProfileMods.Where(m => m.ClientSideChecked).Select(m => $"@{Functions.SafeName(m.Name, true)}"));
+            string serverMods = string.Join(";", Profile.ProfileMods.Where(m => m.ServerSideChecked).Select(m => $"@{Functions.SafeName(m.Name, true)}"));
             List<string> arguments = new List<string>
             {
                 $"-port={Profile.Port}",

--- a/FASTER/ViewModel/ProfileViewModel.cs
+++ b/FASTER/ViewModel/ProfileViewModel.cs
@@ -178,8 +178,8 @@ namespace FASTER.ViewModel
             string config        = Path.Combine(Properties.Settings.Default.serverPath, "Servers", Profile.Id, "server_config.cfg");
             string basic         = Path.Combine(Properties.Settings.Default.serverPath, "Servers", Profile.Id, "server_basic.cfg");
 
-            string playerMods = string.Join(";", Profile.ProfileMods.Where(m => m.ClientSideChecked).Select(m => $"@{Functions.SafeName(m.Name, true)}"));
-            string serverMods = string.Join(";", Profile.ProfileMods.Where(m => m.ServerSideChecked).Select(m => $"@{Functions.SafeName(m.Name, true)}"));
+            string playerMods = string.Join(";", Profile.ProfileMods.Where(m => m.ClientSideChecked).Select(m => $"{Functions.SafeName(m.Name, true)}"));
+            string serverMods = string.Join(";", Profile.ProfileMods.Where(m => m.ServerSideChecked).Select(m => $"{Functions.SafeName(m.Name, true)}"));
             List<string> arguments = new List<string>
             {
                 $"-port={Profile.Port}",

--- a/FASTER/Views/LocalMods.xaml.cs
+++ b/FASTER/Views/LocalMods.xaml.cs
@@ -92,7 +92,7 @@ namespace FASTER.Views
             if (!Directory.Exists(localMod.Path)) return;
 
             try
-            { Process.Start(localMod.Path); }
+            { Process.Start("explorer.exe", localMod.Path); }
             catch (Exception ex)
             { MessageBox.Show("Impossible to open the mod : " + ex.Message); }
         }


### PR DESCRIPTION
As of 1.7 update it's impossible to load local mods due to the SafeName function changing the local path.
SafeName method should in theory make sure that the path is valid, but is actually ignoring legal characters in windows paths, characters used for a lot of mod names. This pull request fixes this issue, and makes possible to use the junctions inside a !Workshop folder in a standard steam client installation out of the box, thus enabling to use a steam client install and workshop mods.

I've tested this with local mods only. I'll check back for steam mods, but lack of documentation all around the codebase is not making it any easier (why we need a SafeName function in first place?).