### PR TITLE
Fixes openmod method not working

### DIFF
--- a/FASTER/Views/LocalMods.xaml.cs
+++ b/FASTER/Views/LocalMods.xaml.cs
@@ -92,7 +92,7 @@ namespace FASTER.Views
             if (!Directory.Exists(localMod.Path)) return;
 
             try
-            { Process.Start(localMod.Path); }
+            { Process.Start("explorer.exe", localMod.Path); }
             catch (Exception ex)
             { MessageBox.Show("Impossible to open the mod : " + ex.Message); }
         }


### PR DESCRIPTION
The Open mod button was returning "Access Denied". Solved the issue by starting an explorer.exe istance with the mod folder path as argument. Works like a charm.