### PR TITLE
Add VN and CLSA options

### DIFF
--- a/FASTER/Models/ServerProfile.cs
+++ b/FASTER/Models/ServerProfile.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Windows.Controls.Primitives;
 using System.Xml.Serialization;
 
@@ -54,6 +55,8 @@ namespace FASTER.Models
         private bool _missionOverride;
         private bool _contactDlcChecked;
         private bool _gmDlcChecked;
+        private bool _pfDlcChecked;
+        private bool _clsaDlcChecked;
         private bool _enableHT = true;
         private bool _enableRanking;
 
@@ -148,6 +151,26 @@ namespace FASTER.Models
             {
                 _gmDlcChecked = value;
                 RaisePropertyChanged("GMDLCChecked");
+            }
+        }
+
+        public bool PFDLCChecked
+        {
+            get => _pfDlcChecked;
+            set
+            {
+                _pfDlcChecked = value;
+                RaisePropertyChanged("PFDLCChecked");
+            }
+        }
+
+        public bool CLSADLCChecked
+        {
+            get => _clsaDlcChecked;
+            set
+            {
+                _clsaDlcChecked = value;
+                RaisePropertyChanged("CLSADLCChecked");
             }
         }
 
@@ -297,6 +320,32 @@ namespace FASTER.Models
             return p;
         }
 
+        public string GetDlcAndPlayerMods(string playerMods)
+        {
+            StringBuilder mods = new StringBuilder();
+            if (ContactDLCChecked)
+            {
+                _ = mods.Append("contact;");
+            }
+            if (GMDLCChecked)
+            {
+                _ = mods.Append("gm;");
+            }
+            if (PFDLCChecked)
+            {
+                _ = mods.Append("vn;");
+            }
+            if (CLSADLCChecked)
+            {
+                _ = mods.Append("clsa;");
+            }
+            if (!string.IsNullOrWhiteSpace(playerMods))
+            {
+                _ = mods.Append($"{playerMods};");
+            }
+            return !string.IsNullOrWhiteSpace(mods.ToString()) ? $" \"-mod={mods}\"" : "";
+        }
+
         private string GetCommandLine()
         {
             
@@ -313,7 +362,7 @@ namespace FASTER.Models
                 $" \"-cfg={basic}\"",
                 $" \"-profiles={Path.Combine(ArmaPath, "Servers", Id)}\"",
                 $" -name={Id}",
-                $"{(!string.IsNullOrWhiteSpace(playerMods) || ContactDLCChecked || GMDLCChecked ? $" \"-mod={(ContactDLCChecked ? "contact;" : "")}{(GMDLCChecked ? "GM;" : "")}{(!string.IsNullOrWhiteSpace(playerMods) ? playerMods + ";" : "" )}\"" : "")}",
+                GetDlcAndPlayerMods(playerMods),
                 $"{(!string.IsNullOrWhiteSpace(serverMods) ? $" \"-serverMod={serverMods};\"" : "")}",
                 $"{(EnableHyperThreading ? " -enableHT" : "")}",
                 $"{(ServerCfg.AllowedFilePatching != ServerCfgArrays.AllowFilePatchingStrings[0] ? " -filePatching" : "")}",

--- a/FASTER/ViewModel/ProfileViewModel.cs
+++ b/FASTER/ViewModel/ProfileViewModel.cs
@@ -87,7 +87,7 @@ namespace FASTER.ViewModel
                 $" \"-profiles={Path.Combine(Profile.ArmaPath, "Servers", $"{Profile.Id}_hc{hc}")}\"",
                 " -nosound",
                 $" -port={Profile.Port}",
-                $"{(!string.IsNullOrWhiteSpace(headlessMods) || Profile.ContactDLCChecked || Profile.GMDLCChecked ? $" \"-mod={(Profile.ContactDLCChecked ? "contact;" : "")}{(Profile.GMDLCChecked ? "GM;" : "")}{(!string.IsNullOrWhiteSpace(headlessMods) ? headlessMods + ";" : "")}\"" : "")}",
+                Profile.GetDlcAndPlayerMods(headlessMods),
                 $"{(Profile.ServerCfg.MaxMemOverride ? $" -maxMem={Profile.ServerCfg.MaxMem}" : "")}",
                 $"{(Profile.ServerCfg.CpuCountOverride ? $" -cpuCount={Profile.ServerCfg.CpuCount}" : "")}",
                 $"{(Profile.EnableHyperThreading ? " -enableHT" : "")}",

--- a/FASTER/Views/Profile.xaml
+++ b/FASTER/Views/Profile.xaml
@@ -85,9 +85,15 @@
                                         <TextBlock Text="Clear Keys" Margin="10,0" />
                                     </StackPanel>
                                 </Button>
-                                <StackPanel Orientation="Horizontal">
-                                    <CheckBox IsChecked="{Binding Profile.ContactDLCChecked}" Content="Contact DLC" Margin="10,3"/>
-                                    <CheckBox IsChecked="{Binding Profile.GMDLCChecked}" Content="GM DLC" Margin="10,3"/>
+                                <StackPanel Orientation="Vertical">
+                                    <StackPanel Orientation="Horizontal">
+                                        <CheckBox IsChecked="{Binding Profile.ContactDLCChecked}" Content="Contact DLC" Margin="10,3" Width="105"/>
+                                        <CheckBox IsChecked="{Binding Profile.GMDLCChecked}" Content="GM DLC" Margin="10,3"/>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal">
+                                        <CheckBox IsChecked="{Binding Profile.PFDLCChecked}" Content="Prairie Fire DLC" Margin="10,3" Width="105"/>
+                                        <CheckBox IsChecked="{Binding Profile.CLSADLCChecked}" Content="CLSA DLC" Margin="10,3"/>
+                                    </StackPanel>
                                 </StackPanel>
                             </StackPanel>
                             <DataGrid Grid.Row="1" ItemsSource="{Binding Path=Profile.ProfileMods, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" CanUserReorderColumns="False" CanUserSortColumns="True" AutoGenerateColumns="False" CanUserAddRows="False">


### PR DESCRIPTION
(Sorry for the double-PR, it was easier to make this for 1.8 starting fresh rather than retrofitting). 

- Added checkboxes for Prairie Fire and CLSA DLCs

To keep the window width the same, I used a vertical stack panel to contain two horizontal ones. The first item in both horizontal stack panels have a fixed-width so that the second items' boxes line up.

In addition, since the single-line creation of the mod string is getting hard to read, I extracted the one-liner into a dedicated method. It takes the profile mods as an argument so it can also be used for the headless client mod string. 