### PR TITLE
Add ability to filter profile mods list

### DIFF
--- a/FASTER/Models/ServerProfile.cs
+++ b/FASTER/Models/ServerProfile.cs
@@ -224,32 +224,39 @@ namespace FASTER.Models
             }
         }
 
-        public List<ProfileMod> FilteredProfileMods => ProfileMods.Where(m => {
-            if (string.IsNullOrEmpty(ProfileModsFilter))
+        public List<ProfileMod> FilteredProfileMods
+        {
+            get
             {
-                return true;
-            }
-            var pattern = ProfileModsFilter;
-            if (!ProfileModsFilterIsRegex)
-            {
-                pattern = Regex.Replace(pattern, @"[\\\{\}\*\+\?\|\^\$\.\[\]\(\)]", "\\$&");
-            }
+                var filteredProfileMods = _profileMods.Where(m => {
+                    if (string.IsNullOrEmpty(ProfileModsFilter))
+                    {
+                        return true;
+                    }
+                    var pattern = ProfileModsFilter;
+                    if (!ProfileModsFilterIsRegex)
+                    {
+                        pattern = Regex.Replace(pattern, @"[\\\{\}\*\+\?\|\^\$\.\[\]\(\)]", "\\$&");
+                    }
 
-            if (ProfileModsFilterIsWholeWord)
-            {
-                if (!Regex.IsMatch(pattern[0].ToString(), @"\B"))
-                {
-                    pattern = $"\\b{pattern}";
-                }
-                if (!Regex.IsMatch(pattern[pattern.Length - 1].ToString(), @"\B"))
-                {
-                    pattern = $"{pattern}\\b";
-                }
-            }
+                    if (ProfileModsFilterIsWholeWord)
+                    {
+                        if (!Regex.IsMatch(pattern[0].ToString(), @"\B"))
+                        {
+                            pattern = $"\\b{pattern}";
+                        }
+                        if (!Regex.IsMatch(pattern[pattern.Length - 1].ToString(), @"\B"))
+                        {
+                            pattern = $"{pattern}\\b";
+                        }
+                    }
 
-            var options = ProfileModsFilterIsCaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase;
-            return Regex.IsMatch(m.Name, pattern, options);
-        }).ToList();
+                    var options = ProfileModsFilterIsCaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase;
+                    return Regex.IsMatch(m.Name, pattern, options);
+                }).ToList();
+                return filteredProfileMods;
+            }
+        }
 
         public string ProfileModsFilter
         {

--- a/FASTER/Models/ServerProfile.cs
+++ b/FASTER/Models/ServerProfile.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Controls.Primitives;
 using System.Xml.Serialization;
 
@@ -61,6 +62,10 @@ namespace FASTER.Models
         private bool _enableRanking;
 
         private List<ProfileMod> _profileMods = new List<ProfileMod>();
+        private string _profileModsFilter = "";
+        private bool _profileModsFilterIsCaseSensitive = false;
+        private bool _profileModsFilterIsWholeWord = false;
+        private bool _profileModsFilterIsRegex = false;
         private ServerCfg _serverCfg;
         private Arma3Profile _armaProfile;
         private BasicCfg _basicCfg;
@@ -215,6 +220,78 @@ namespace FASTER.Models
                 _profileMods.ForEach(m => m.PropertyChanged += Item_PropertyChanged);
 
                 RaisePropertyChanged("ProfileMods");
+                RaisePropertyChanged("FilteredProfileMods");
+            }
+        }
+
+        public List<ProfileMod> FilteredProfileMods => ProfileMods.Where(m => {
+            if (string.IsNullOrEmpty(ProfileModsFilter))
+            {
+                return true;
+            }
+            var pattern = ProfileModsFilter;
+            if (!ProfileModsFilterIsRegex)
+            {
+                pattern = Regex.Replace(pattern, @"[\\\{\}\*\+\?\|\^\$\.\[\]\(\)]", "\\$&");
+            }
+
+            if (ProfileModsFilterIsWholeWord)
+            {
+                if (!Regex.IsMatch(pattern[0].ToString(), @"\B"))
+                {
+                    pattern = $"\\b{pattern}";
+                }
+                if (!Regex.IsMatch(pattern[pattern.Length - 1].ToString(), @"\B"))
+                {
+                    pattern = $"{pattern}\\b";
+                }
+            }
+
+            var options = ProfileModsFilterIsCaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase;
+            return Regex.IsMatch(m.Name, pattern, options);
+        }).ToList();
+
+        public string ProfileModsFilter
+        {
+            get => _profileModsFilter;
+            set
+            {
+                _profileModsFilter = value;
+                RaisePropertyChanged("ProfileModsFilter");
+                RaisePropertyChanged("FilteredProfileMods");
+            }
+        }
+
+        public bool ProfileModsFilterIsCaseSensitive
+        {
+            get => _profileModsFilterIsCaseSensitive;
+            set
+            {
+                _profileModsFilterIsCaseSensitive = value;
+                RaisePropertyChanged("ProfileModsFilterIsCaseSensitive");
+                RaisePropertyChanged("FilteredProfileMods");
+            }
+        }
+
+        public bool ProfileModsFilterIsWholeWord
+        {
+            get => _profileModsFilterIsWholeWord;
+            set
+            {
+                _profileModsFilterIsWholeWord = value;
+                RaisePropertyChanged("ProfileModsFilterIsWholeWord");
+                RaisePropertyChanged("FilteredProfileMods");
+            }
+        }
+
+        public bool ProfileModsFilterIsRegex
+        {
+            get => _profileModsFilterIsRegex;
+            set
+            {
+                _profileModsFilterIsRegex = value;
+                RaisePropertyChanged("ProfileModsFilterIsRegex");
+                RaisePropertyChanged("FilteredProfileMods");
             }
         }
 

--- a/FASTER/Views/Profile.xaml
+++ b/FASTER/Views/Profile.xaml
@@ -64,6 +64,7 @@
                                 <RowDefinition Height="auto"/>
                                 <RowDefinition/>
                                 <RowDefinition Height="auto"/>
+                                <RowDefinition Height="auto"/>
                             </Grid.RowDefinitions>
                             <StackPanel Orientation="Horizontal" Panel.ZIndex="1">
                                 <Button Margin="0, 5" Style="{StaticResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" Padding="5,3" Click="LoadFromFile_Click">
@@ -96,7 +97,7 @@
                                     </Expander>
                                 </Canvas>
                             </StackPanel>
-                            <DataGrid Grid.Row="1" ItemsSource="{Binding Path=Profile.ProfileMods, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" CanUserReorderColumns="False" CanUserSortColumns="True" AutoGenerateColumns="False" CanUserAddRows="False">
+                            <DataGrid Grid.Row="1" ItemsSource="{Binding Path=Profile.FilteredProfileMods, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" CanUserReorderColumns="False" CanUserSortColumns="True" AutoGenerateColumns="False" CanUserAddRows="False">
                                 <DataGrid.Resources>
 
                                     <ContextMenu x:Key="LoadContextMenu">
@@ -283,6 +284,25 @@
                                 <TextBlock Text="{Binding Path=Profile.ServerModsChecked, StringFormat={}ServerSide : {0} mods}" Grid.Column="0"/>
                                 <TextBlock Text="{Binding Path=Profile.ClientModsChecked, StringFormat={}ClientSide : {0} mods}" Grid.Column="1"/>
                                 <TextBlock Text="{Binding Path=Profile.HeadlessModsChecked, StringFormat={}Headless Client : {0} mods}" Grid.Column="2"/>
+                            </Grid>
+                            <Grid Grid.Row="3" Margin="5">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition/>
+                                    <ColumnDefinition Width="auto"/>
+                                    <ColumnDefinition Width="auto"/>
+                                    <ColumnDefinition Width="auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Grid.Column="0" Margin="5,2" IsReadOnly="False" mah:TextBoxHelper.UseFloatingWatermark="True"
+                                 mah:TextBoxHelper.Watermark="Filter:" Text="{Binding Path=Profile.ProfileModsFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <ToggleButton Grid.Column="1" Content="{iconPacks:Material Kind=FormatLetterCase}" IsChecked="{Binding Path=Profile.ProfileModsFilterIsCaseSensitive}" 
+                                              BorderThickness="0" Width="30" Height="30" Margin="2" Padding="0" 
+                                              ToolTip="Match Case" Style="{StaticResource MahApps.Styles.ToggleButton.Flat}"/>
+                                <ToggleButton Grid.Column="2" Content="{iconPacks:Material Kind=FormatLetterMatches}" IsChecked="{Binding Path=Profile.ProfileModsFilterIsWholeWord}" 
+                                              BorderThickness="0" Width="30" Height="30" Margin="2" Padding="0" 
+                                              ToolTip="Match Whole Word" Style="{StaticResource MahApps.Styles.ToggleButton.Flat}"/>
+                                <ToggleButton Grid.Column="3" Content="{iconPacks:Material Kind=Regex}" IsChecked="{Binding Path=Profile.ProfileModsFilterIsRegex}" 
+                                              BorderThickness="0" Width="30" Height="30" Margin="2" Padding="0" 
+                                              ToolTip="Use Regular Expressions" Style="{StaticResource MahApps.Styles.ToggleButton.Flat}"/>
                             </Grid>
                         </Grid>
                     </GroupBox>


### PR DESCRIPTION
Based on feedback from #43, this is a simple text input at the bottom of the mod list. It has the standard options for doing case-sensitive, whole-word, and regex. It also doesn't modify the internal Profile Mods list, but any modifications (checking Server/Client/etc.), will propagate into the underlying list. 

I wouldn't say it's the prettiest solution in the world, but it does work. 