### PR TITLE
Add ability to filter mods and deployment lists

### DIFF
--- a/FASTER/Views/Deployment.xaml
+++ b/FASTER/Views/Deployment.xaml
@@ -17,11 +17,15 @@
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <models:FolderSizeConverter x:Key="SizeConverter" />
         <models:NotBooleanToVisibilityConverter x:Key="BoolToHide" />
+        <models:ProfileModsFilterIsInvalidBorderColorConverter x:Key="ProfileModsFilterIsInvalidBorderColorConverter"/>
+        <models:ProfileModsFilterIsInvalidBackgroundColorConverter x:Key="ProfileModsFilterIsInvalidBackgroundColorConverter"/>
+        <models:ProfileModsFilterIsInvalidTextConverter x:Key="ProfileModsFilterIsInvalidTextConverter"/>
     </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <DockPanel HorizontalAlignment="Stretch" Margin="10,10,5,5">
             <DockPanel.Effect>
@@ -48,7 +52,7 @@
             </Canvas>-->
         </DockPanel>
         <DataGrid Grid.Row="1" Grid.Column="0" Margin="10,5,10,10"
-                  ItemsSource="{Binding Path=Deployment.DeployMods, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                  ItemsSource="{Binding Path=Deployment.FilteredDeployMods, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                   CanUserReorderColumns="False" CanUserSortColumns="True" AutoGenerateColumns="False"
                   CanUserAddRows="False">
             <DataGrid.Effect>
@@ -129,5 +133,40 @@
                 </DataGridTextColumn>
             </DataGrid.Columns>
         </DataGrid>
+
+        <Grid Grid.Row="2" Margin="50px 0px 50px 10px">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="600px"/>
+                <ColumnDefinition Width="auto"/>
+                <ColumnDefinition Width="auto"/>
+                <ColumnDefinition Width="auto"/>
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0" Margin="0,0" BorderThickness="1"
+                                        BorderBrush="{Binding Path=Deployment.DeployModsFilterIsInvalid, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ProfileModsFilterIsInvalidBorderColorConverter}}">
+                <TextBox IsReadOnly="False" mah:TextBoxHelper.UseFloatingWatermark="True"
+                                             mah:TextBoxHelper.Watermark="Filter:" Text="{Binding Path=Deployment.DeployModsFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            </Border>
+            <Canvas Grid.Column="0" Margin="0,2"
+                                        Visibility="{Binding Path=Deployment.DeployModsFilterIsInvalid, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Border BorderThickness="1" BorderBrush="{Binding Path=Deployment.DeployModsFilterIsInvalid, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ProfileModsFilterIsInvalidBorderColorConverter}}">
+                    <TextBlock Foreground="White" Padding="5,1"
+                                                   Text="{Binding Path=Deployment.DeployModsFilterIsInvalid, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ProfileModsFilterIsInvalidTextConverter}}"
+                                                   Background="{Binding Path=Deployment.DeployModsFilterIsInvalid, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ProfileModsFilterIsInvalidBackgroundColorConverter}}" />
+                </Border>
+            </Canvas>
+            <ToggleButton Grid.Column="1" Content="{iconPacks:Material Kind=FormatLetterCase}" IsChecked="{Binding Path=Deployment.DeployModsFilterIsCaseSensitive}" 
+                                              BorderThickness="0" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"
+                                              Margin="2" Padding="0" 
+                                              ToolTip="Match Case" Style="{StaticResource MahApps.Styles.ToggleButton.Flat}"/>
+            <ToggleButton Grid.Column="2" Content="{iconPacks:Material Kind=FormatLetterMatches}" IsChecked="{Binding Path=Deployment.DeployModsFilterIsWholeWord}" 
+                                              BorderThickness="0"
+                                              Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"
+                                              Margin="2" Padding="0" 
+                                              ToolTip="Match Whole Word" Style="{StaticResource MahApps.Styles.ToggleButton.Flat}"/>
+            <ToggleButton Grid.Column="3" Content="{iconPacks:Material Kind=Regex}" IsChecked="{Binding Path=Deployment.DeployModsFilterIsRegex}" 
+                                              BorderThickness="0" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"
+                                              Margin="2" Padding="0" 
+                                              ToolTip="Use Regular Expressions" Style="{StaticResource MahApps.Styles.ToggleButton.Flat}"/>
+        </Grid>
     </Grid>
 </UserControl>

--- a/FASTER/Views/Mods.xaml
+++ b/FASTER/Views/Mods.xaml
@@ -18,6 +18,9 @@
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <models:FolderSizeConverter x:Key="SizeConverter" />
         <models:NotBooleanToVisibilityConverter x:Key="BoolToHide" />
+        <models:ProfileModsFilterIsInvalidBorderColorConverter x:Key="ProfileModsFilterIsInvalidBorderColorConverter"/>
+        <models:ProfileModsFilterIsInvalidBackgroundColorConverter x:Key="ProfileModsFilterIsInvalidBackgroundColorConverter"/>
+        <models:ProfileModsFilterIsInvalidTextConverter x:Key="ProfileModsFilterIsInvalidTextConverter"/>
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -27,6 +30,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />
+            <RowDefinition Height="auto"/>
         </Grid.RowDefinitions>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="10,10,5,5">
@@ -59,9 +63,9 @@
                HorizontalAlignment="Center" VerticalAlignment="Center"
                Foreground="{DynamicResource MaterialDesignBackground}" Visibility="Visible" />
         <!--<DataGrid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Margin="5" CanUserReorderColumns="False" CanUserResizeRows="False" GridLinesVisibility="All" CanUserSortColumns="True" CanUserAddRows="False" AutoGenerateColumns="False"
-                  ItemsSource="{Binding Path=ModsCollection.ArmaMods, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">-->
+                  ItemsSource="{Binding Path=ModsCollection.FilteredArmaMods, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">-->
         <DataGrid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Margin="10,5,10,10"
-                  ItemsSource="{Binding Path=ModsCollection.ArmaMods, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                  ItemsSource="{Binding Path=ModsCollection.FilteredArmaMods, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                   CanUserReorderColumns="False" CanUserSortColumns="True" AutoGenerateColumns="False"
                   CanUserAddRows="False">
             <DataGrid.Effect>
@@ -142,5 +146,39 @@
             </DataGrid.Columns>
         </DataGrid>
 
+        <Grid Grid.Row="2" Margin="50px 0px 50px 10px">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="650px"/>
+                <ColumnDefinition Width="auto"/>
+                <ColumnDefinition Width="auto"/>
+                <ColumnDefinition Width="auto"/>
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0" Margin="0,0" BorderThickness="1"
+                                        BorderBrush="{Binding Path=ModsCollection.ArmaModsFilterIsInvalid, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ProfileModsFilterIsInvalidBorderColorConverter}}">
+                <TextBox IsReadOnly="False" mah:TextBoxHelper.UseFloatingWatermark="True"
+                                             mah:TextBoxHelper.Watermark="Filter:" Text="{Binding Path=ModsCollection.ArmaModsFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            </Border>
+            <Canvas Grid.Column="0" Margin="0,2"
+                                        Visibility="{Binding Path=ModsCollection.ArmaModsFilterIsInvalid, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Border BorderThickness="1" BorderBrush="{Binding Path=ModsCollection.ArmaModsFilterIsInvalid, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ProfileModsFilterIsInvalidBorderColorConverter}}">
+                    <TextBlock Foreground="White" Padding="5,1"
+                                                   Text="{Binding Path=ModsCollection.ArmaModsFilterIsInvalid, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ProfileModsFilterIsInvalidTextConverter}}"
+                                                   Background="{Binding Path=ModsCollection.ArmaModsFilterIsInvalid, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ProfileModsFilterIsInvalidBackgroundColorConverter}}" />
+                </Border>
+            </Canvas>
+            <ToggleButton Grid.Column="1" Content="{iconPacks:Material Kind=FormatLetterCase}" IsChecked="{Binding Path=ModsCollection.ArmaModsFilterIsCaseSensitive}" 
+                                              BorderThickness="0" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"
+                                              Margin="2" Padding="0" 
+                                              ToolTip="Match Case" Style="{StaticResource MahApps.Styles.ToggleButton.Flat}"/>
+            <ToggleButton Grid.Column="2" Content="{iconPacks:Material Kind=FormatLetterMatches}" IsChecked="{Binding Path=ModsCollection.ArmaModsFilterIsWholeWord}" 
+                                              BorderThickness="0"
+                                              Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"
+                                              Margin="2" Padding="0" 
+                                              ToolTip="Match Whole Word" Style="{StaticResource MahApps.Styles.ToggleButton.Flat}"/>
+            <ToggleButton Grid.Column="3" Content="{iconPacks:Material Kind=Regex}" IsChecked="{Binding Path=ModsCollection.ArmaModsFilterIsRegex}" 
+                                              BorderThickness="0" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"
+                                              Margin="2" Padding="0" 
+                                              ToolTip="Use Regular Expressions" Style="{StaticResource MahApps.Styles.ToggleButton.Flat}"/>
+        </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Description
Add the same filtering logic from the profile screens to the mods list and the deployment list. 

## Motivation and Context
#76 

## How Has This Been Tested?
It's the same logic from the profile filtering, if I'd change anything, it might be to refactor the filtering code into something more reusable. But I didn't see the need currently. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
