### PR TITLE
Optional client mods

### DIFF
--- a/FASTER/Models/ServerProfile.cs
+++ b/FASTER/Models/ServerProfile.cs
@@ -215,6 +215,7 @@ namespace FASTER.Models
         public int ServerModsChecked => ProfileMods.Count(m => m.ServerSideChecked);
         public int ClientModsChecked => ProfileMods.Count(m => m.ClientSideChecked);
         public int HeadlessModsChecked => ProfileMods.Count(m => m.HeadlessChecked);
+        public int OptModsChecked => ProfileMods.Count(m => m.OptChecked);
 
         public string CommandLine => GetCommandLine();
 
@@ -514,6 +515,7 @@ namespace FASTER.Models
             RaisePropertyChanged("ServerModsChecked");
             RaisePropertyChanged("ClientModsChecked");
             RaisePropertyChanged("HeadlessModsChecked");
+            RaisePropertyChanged("OptModsChecked");
         }
 
         private void Class_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -535,6 +537,7 @@ namespace FASTER.Models
         private bool    serverSideChecked;
         private bool    clientSideChecked;
         private bool    headlessChecked;
+        private bool    optChecked;
         private ushort? loadPriority;
         private bool    isLocal;
         private uint    _id;
@@ -547,7 +550,7 @@ namespace FASTER.Models
             {
                 serverSideChecked = value;
                 RaisePropertyChanged("ServerSideChecked");
-                RaisePropertyChanged("HeadlessModsChecked");
+                RaisePropertyChanged("ServerModsChecked");
             }
         }
         public bool ClientSideChecked
@@ -568,6 +571,17 @@ namespace FASTER.Models
                 headlessChecked = value;
                 RaisePropertyChanged("HeadlessChecked");
                 RaisePropertyChanged("HeadlessModsChecked");
+            }
+        }
+
+        public bool OptChecked
+        {
+            get => optChecked;
+            set
+            {
+                optChecked = value;
+                RaisePropertyChanged("OptChecked");
+                RaisePropertyChanged("OptModsChecked");
             }
         }
 

--- a/FASTER/ViewModel/ProfileViewModel.cs
+++ b/FASTER/ViewModel/ProfileViewModel.cs
@@ -236,7 +236,7 @@ namespace FASTER.ViewModel
             
             var links = Directory.EnumerateDirectories(armaPath).Select(d => new DirectoryInfo(d)).Where(d => d.Attributes.HasFlag(FileAttributes.ReparsePoint));
             uint MissingMods = 0;
-            foreach (ProfileMod profileMod in Profile.ProfileMods.Where(m => m.ClientSideChecked || m.HeadlessChecked || m.ServerSideChecked))
+            foreach (ProfileMod profileMod in Profile.ProfileMods.Where(m => m.ServerSideChecked || m.ClientSideChecked || m.HeadlessChecked  || m.OptChecked))
             {
                 if (!links.Any(l => l.Name == $"@{Functions.SafeName(profileMod.Name)}"))
                     MissingMods++;
@@ -359,7 +359,10 @@ namespace FASTER.ViewModel
                 MainWindow.Instance.IFlyoutMessage.Content = $"The SteamCMD path does not exist :\n{Properties.Settings.Default.modStagingDirectory}";
                 return;
             }
-            var steamMods = Profile.ProfileMods.Where(p => p.ClientSideChecked).ToList();
+
+            var clientMods = Profile.ProfileMods.Where(p => p.ClientSideChecked).ToList();
+            var optionalMods = Profile.ProfileMods.Where(p => p.OptChecked).ToList();
+            var steamMods = clientMods.Union(optionalMods).ToList();
 
             foreach (var line in steamMods)
             {
@@ -486,19 +489,29 @@ namespace FASTER.ViewModel
                     case "Server":
                         {
                             if (from == "Client") mod.ServerSideChecked = mod.ClientSideChecked;
-                            if (from == "Headless") mod.ServerSideChecked = mod.HeadlessChecked;
+                            if (from == "HC") mod.ServerSideChecked = mod.HeadlessChecked;
+                            if (from == "Opt") mod.ServerSideChecked = mod.OptChecked;
                             break;
                         }
                     case "Client":
                         {
                             if (from == "Server") mod.ClientSideChecked = mod.ServerSideChecked;
-                            if (from == "Headless") mod.ClientSideChecked = mod.HeadlessChecked;
+                            if (from == "HC") mod.ClientSideChecked = mod.HeadlessChecked;
+                            if (from == "Opt") mod.ClientSideChecked = mod.OptChecked;
                             break;
                         }
-                    case "Headless":
+                    case "HC":
                         {
-                            if (from == "Client") mod.HeadlessChecked = mod.ClientSideChecked;
                             if (from == "Server") mod.HeadlessChecked = mod.ServerSideChecked;
+                            if (from == "Client") mod.HeadlessChecked = mod.ClientSideChecked;
+                            if (from == "Opt") mod.HeadlessChecked = mod.OptChecked;
+                            break;
+                        }
+                    case "Opt":
+                        {
+                            if (from == "Server") mod.OptChecked = mod.ServerSideChecked;
+                            if (from == "Client") mod.OptChecked = mod.ClientSideChecked;
+                            if (from == "HC") mod.OptChecked = mod.HeadlessChecked;
                             break;
                         }
                 }
@@ -517,8 +530,11 @@ namespace FASTER.ViewModel
                     case "Client":
                         mod.ClientSideChecked = select;
                         break;
-                    case "Headless":
+                    case "HC":
                         mod.HeadlessChecked = select;
+                        break;
+                    case "Opt":
+                        mod.OptChecked = select;
                         break;
                 }
             }

--- a/FASTER/Views/Profile.xaml
+++ b/FASTER/Views/Profile.xaml
@@ -135,6 +135,11 @@
                                                 <iconPacks:PackIconModern Kind="PageCopy" Margin="5"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
+                                        <MenuItem Tag="Server" Header="Copy From Optional" Click="CopyFromOpt">
+                                            <MenuItem.Icon>
+                                                <iconPacks:PackIconModern Kind="PageCopy"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
                                     </ContextMenu>
                                     <ContextMenu x:Key="ClientContextMenu">
                                         <MenuItem Tag="Client" Header="Select All" Click="ModsSelectAll">
@@ -157,24 +162,61 @@
                                                 <iconPacks:PackIconModern Kind="PageCopy"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
-                                    </ContextMenu>
-                                    <ContextMenu x:Key="HeadlessContextMenu">
-                                        <MenuItem Tag="Headless" Header="Select All" Click="ModsSelectAll">
-                                            <MenuItem.Icon>
-                                                <iconPacks:PackIconModern Kind="CheckmarkThick"/>
-                                            </MenuItem.Icon>
-                                        </MenuItem>
-                                        <MenuItem Tag="Headless" Header="Select None" Click="ModsSelectNone">
-                                            <MenuItem.Icon>
-                                                <iconPacks:PackIconModern Kind="CheckmarkUncrossed"/>
-                                            </MenuItem.Icon>
-                                        </MenuItem>
-                                        <MenuItem Tag="Headless" Header="Copy From Server" Click="CopyFromServer">
+                                        <MenuItem Tag="Client" Header="Copy From Optional" Click="CopyFromOpt">
                                             <MenuItem.Icon>
                                                 <iconPacks:PackIconModern Kind="PageCopy"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
-                                        <MenuItem Tag="Headless" Header="Copy From Client" Click="CopyFromClient">
+                                    </ContextMenu>
+                                    <ContextMenu x:Key="HeadlessContextMenu">
+                                        <MenuItem Tag="HC" Header="Select All" Click="ModsSelectAll">
+                                            <MenuItem.Icon>
+                                                <iconPacks:PackIconModern Kind="CheckmarkThick"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Tag="HC" Header="Select None" Click="ModsSelectNone">
+                                            <MenuItem.Icon>
+                                                <iconPacks:PackIconModern Kind="CheckmarkUncrossed"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Tag="HC" Header="Copy From Server" Click="CopyFromServer">
+                                            <MenuItem.Icon>
+                                                <iconPacks:PackIconModern Kind="PageCopy"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Tag="HC" Header="Copy From Client" Click="CopyFromClient">
+                                            <MenuItem.Icon>
+                                                <iconPacks:PackIconModern Kind="PageCopy"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Tag="HC" Header="Copy From Optional" Click="CopyFromOpt">
+                                            <MenuItem.Icon>
+                                                <iconPacks:PackIconModern Kind="PageCopy"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                    </ContextMenu>
+                                    <ContextMenu x:Key="OptContextMenu">
+                                        <MenuItem Tag="Opt" Header="Select All" Click="ModsSelectAll">
+                                            <MenuItem.Icon>
+                                                <iconPacks:PackIconModern Kind="CheckmarkThick"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Tag="Opt" Header="Select None" Click="ModsSelectNone">
+                                            <MenuItem.Icon>
+                                                <iconPacks:PackIconModern Kind="CheckmarkUncrossed"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Tag="Opt" Header="Copy From Server" Click="CopyFromServer">
+                                            <MenuItem.Icon>
+                                                <iconPacks:PackIconModern Kind="PageCopy"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Tag="Opt" Header="Copy From Client" Click="CopyFromClient">
+                                            <MenuItem.Icon>
+                                                <iconPacks:PackIconModern Kind="PageCopy"/>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Tag="Opt" Header="Copy From Headless" Click="CopyFromHeadless">
                                             <MenuItem.Icon>
                                                 <iconPacks:PackIconModern Kind="PageCopy"/>
                                             </MenuItem.Icon>
@@ -225,7 +267,7 @@
                                                     </Setter.Value>
                                                 </Setter>
                                             </Trigger>
-                                            <Trigger Property="Content" Value="Headless">
+                                            <Trigger Property="Content" Value="HC">
                                                 <Setter Property="ContextMenu" Value="{StaticResource HeadlessContextMenu}" />
                                                 <Setter Property="ContentTemplate">
                                                     <Setter.Value>
@@ -233,6 +275,20 @@
                                                             <ContentControl Content="{Binding}">
                                                                 <ToolTipService.ToolTip>
                                                                     <ToolTip Content="Mods loaded by the Headless Clients" />
+                                                                </ToolTipService.ToolTip>
+                                                            </ContentControl>
+                                                        </DataTemplate>
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </Trigger>
+                                            <Trigger Property="Content" Value="Opt">
+                                                <Setter Property="ContextMenu" Value="{StaticResource OptContextMenu}" />
+                                                <Setter Property="ContentTemplate">
+                                                    <Setter.Value>
+                                                        <DataTemplate>
+                                                            <ContentControl Content="{Binding}">
+                                                                <ToolTipService.ToolTip>
+                                                                    <ToolTip Content="Suggested/Additional/Optional client mods" />
                                                                 </ToolTipService.ToolTip>
                                                             </ContentControl>
                                                         </DataTemplate>
@@ -270,10 +326,17 @@
                                             </DataTemplate>
                                         </DataGridTemplateColumn.CellTemplate>
                                     </DataGridTemplateColumn>
-                                    <DataGridTemplateColumn Header="Headless" Width="auto">
+                                    <DataGridTemplateColumn Header="HC" Width="auto">
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate DataType="models:ProfileMod">
                                                 <CheckBox IsChecked="{Binding HeadlessChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Opt" Width="auto">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate DataType="models:ProfileMod">
+                                                <CheckBox IsChecked="{Binding OptChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center"/>
                                             </DataTemplate>
                                         </DataGridTemplateColumn.CellTemplate>
                                     </DataGridTemplateColumn>
@@ -285,10 +348,12 @@
                                     <ColumnDefinition/>
                                     <ColumnDefinition/>
                                     <ColumnDefinition/>
+                                    <ColumnDefinition/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Text="{Binding Path=Profile.ServerModsChecked, StringFormat={}ServerSide : {0} mods}" Grid.Column="0"/>
                                 <TextBlock Text="{Binding Path=Profile.ClientModsChecked, StringFormat={}ClientSide : {0} mods}" Grid.Column="1"/>
                                 <TextBlock Text="{Binding Path=Profile.HeadlessModsChecked, StringFormat={}Headless Client : {0} mods}" Grid.Column="2"/>
+                                <TextBlock Text="{Binding Path=Profile.OptModsChecked, StringFormat={}Optional : {0} mods}" Grid.Column="3"/>
                             </Grid>
                             <Grid Grid.Row="3" Margin="0">
                                 <Grid.ColumnDefinitions>

--- a/FASTER/Views/Profile.xaml.cs
+++ b/FASTER/Views/Profile.xaml.cs
@@ -43,19 +43,24 @@ namespace FASTER.Views
             ( (ProfileViewModel) DataContext )?.ClearModOrder();
         }
 
-        private void CopyFromClient(object sender, RoutedEventArgs e)
-        {
-            ((ProfileViewModel) DataContext)?.ModsCopyFrom(((MenuItem)sender).Tag, "Client");
-        }
-
         private void CopyFromServer(object sender, RoutedEventArgs e)
         {
             ((ProfileViewModel) DataContext)?.ModsCopyFrom(((MenuItem)sender).Tag, "Server");
         }
 
+        private void CopyFromClient(object sender, RoutedEventArgs e)
+        {
+            ((ProfileViewModel) DataContext)?.ModsCopyFrom(((MenuItem)sender).Tag, "Client");
+        }
+
         private void CopyFromHeadless(object sender, RoutedEventArgs e)
         {
-            ((ProfileViewModel) DataContext)?.ModsCopyFrom(((MenuItem)sender).Tag, "Headless");
+            ((ProfileViewModel) DataContext)?.ModsCopyFrom(((MenuItem)sender).Tag, "HC");
+        }
+
+        private void CopyFromOpt(object sender, RoutedEventArgs e)
+        {
+            ((ProfileViewModel) DataContext)?.ModsCopyFrom(((MenuItem)sender).Tag, "Opt");
         }
 
         private void ModsSelectAll(object sender, RoutedEventArgs e)


### PR DESCRIPTION
- Added the ability to manage optional client mods from the Profile view;
- Renamed the Headless column to HC to save some space for the new OPT column;

## Description
This PR adds a new column to the server profile mods list named OPT, when ticked it copies the mods `.bikey` files automatically along with the mods selected on the Client column, also it changes the Headless column title to HC to make room for the new OPT column.

## Motivation and Context
A friend of mine wanted to be able to manage his server's optional client mods through the GUI automatically instead of having to manually move each `.bikey` file manually to the `keys` folder. I also noticed there was a feature request for this exact thing #24.

## How Has This Been Tested?
I've manually tested this to the best of my ability, and it seems to work. I do invite everyone to test it before merging though.

## Screenshots (if appropriate):
![PROFILE-MODS](https://user-images.githubusercontent.com/8343238/209210213-725c694d-4ba9-44df-bdc4-ac61dec484be.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
