### PR TITLE
{BugFix} Stops all directory keys being added

### DIFF
--- a/FASTER/ViewModel/ProfileViewModel.cs
+++ b/FASTER/ViewModel/ProfileViewModel.cs
@@ -367,7 +367,8 @@ namespace FASTER.ViewModel
             foreach (var line in steamMods)
             {
                 try
-                { mods.AddRange(Directory.GetFiles(Path.Combine(Properties.Settings.Default.modStagingDirectory, line.Id.ToString()), "*.bikey", SearchOption.AllDirectories)); }
+                { mods.AddRange(Directory.GetDirectories(Path.Combine(Properties.Settings.Default.modStagingDirectory, line.Id.ToString()))
+				.SelectMany(subDir => Directory.GetFiles(subDir, "*bikey", SearchOption.TopDirectoryOnly))); }
                 catch (DirectoryNotFoundException)
                 { /*there was no directory*/ }
             }


### PR DESCRIPTION
Basically 

ACEs optionals structure looks like this:
`@ace\optionals\@ace_noactionmenu\keys\*.bikey`
The main key is located here:
`@ace\keys\*.bikey`

Their is no need for it to search that deep. More explanation can be found in https://github.com/Foxlider/FASTER/issues/151

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/Foxlider/FASTER/issues/151

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Basic change no crazy testing needed. Mainly tested on ACE for it's optional `*.bikey`
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.

Credit to [liamcannon](https://github.com/Foxlider/FASTER/commits?author=liamcannon) for helping me with this.