### PR TITLE
Publish to WinGet

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  release:
+    types: [released]
+
+jobs:
+
+  winget:
+    runs-on: windows-latest
+    steps:
+      # Requires forked winget-pkgs: https://github.com/microsoft/winget-pkgs to the same account as this project
+      - name: Submit to WinGet
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Foxlider.FASTER
+          installers-regex: 'Release_x64.zip'
+          max-versions-to-keep: 5
+          token: ${{ secrets.WINGET_TOKEN }} # Classic Personal Access Token with [public_repo, workflow] scopes


### PR DESCRIPTION
## Description

- CI Action to update FASTER on `WinGet` on new Github Release

## Checklist:

- [x] [Foxlider.FASTER version 1.9e](https://github.com/microsoft/winget-pkgs/pull/173998) needs to be merged first
- [x] https://github.com/microsoft/winget-pkgs must be forked to the @Foxlider account
- [x] Classic Personal Access Token with public_repo and workflow scopes must be added to this repository as WINGET_TOKEN
