### PR TITLE
Added scrollbar to Server Profiles list in MainWindow.xaml

### DIFF
--- a/FASTER/MainWindow.xaml
+++ b/FASTER/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<mah:MetroWindow
+<mah:MetroWindow
     x:Class="FASTER.MainWindow"
     
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -42,9 +42,9 @@
         </Grid.ColumnDefinitions>
         <Grid Grid.Column="0">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"></RowDefinition>
-                <RowDefinition></RowDefinition>
-                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <!--Menu Column - Main Items-->
@@ -52,7 +52,7 @@
                 <StackPanel.Effect>
                     <DropShadowEffect BlurRadius="5" RenderingBias="Performance" ShadowDepth="0"/>
                 </StackPanel.Effect>
-                <Label  Content="Main" Margin="10,10,0,0" FontWeight="Bold"/>
+                <Label Content="Main" Margin="10,10,0,0" FontWeight="Bold"/>
                 <ListBox Name="IMainMenuItems" HorizontalAlignment="Stretch">
                     <ToggleButton Name="navSteamUpdater" Style="{StaticResource MahApps.Styles.ToggleButton.WindowCommands}" Click="ToggleButton_Click">
                         <DockPanel Width="180">
@@ -82,17 +82,16 @@
             </StackPanel>
 
             <!--Menu Column - Server Profiles-->
-            <StackPanel Grid.Row="1">
-                <StackPanel.Effect>
-                    <DropShadowEffect BlurRadius="5" RenderingBias="Performance" ShadowDepth="0"/>
-                </StackPanel.Effect>
-                <Separator />
-                <!--<ListBoxItem Margin="2,5" Style="{StaticResource MahApps.Styles.ListBoxItem.HamburgerMenuSeparator}"/>-->
-                <DockPanel>
+            <Grid Grid.Row="1">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <DockPanel Grid.Row="0">
                     <Label Content="Server Profiles" DockPanel.Dock="Left" Margin="10,5" FontWeight="Bold" HorizontalAlignment="Left" VerticalAlignment="Center"/>
                     <Button HorizontalAlignment="Right" Margin="10,0" Click="INewServerProfileButton_Click" Content="{iconPacks:Modern Kind=Add}" Name="INewServerProfileButton" Style="{StaticResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" Height="25" Width="25" VerticalAlignment="Center" Padding="0"/>
                 </DockPanel>
-                <ListBox Name="IServerProfilesMenu" HorizontalAlignment="Stretch" Margin="0,0,0,2" ScrollViewer.VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
+                <ListBox Grid.Row="1" Name="IServerProfilesMenu" HorizontalAlignment="Stretch" Margin="0,0,0,2" ScrollViewer.VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
                     <ListBox.Resources>
                         <ContextMenu x:Key="ProfileContextMenu">
                             <MenuItem Header="Clone" Click="MenuItemClone_Click">
@@ -115,7 +114,7 @@
                         </Style>
                     </ListBox.ItemContainerStyle>
                 </ListBox>
-            </StackPanel>
+            </Grid>
 
             <!--Menu Column - Other Items-->
             <StackPanel Grid.Row="2" TextElement.FontSize="13">
@@ -123,7 +122,6 @@
                     <DropShadowEffect BlurRadius="5" RenderingBias="Performance" ShadowDepth="0"/>
                 </StackPanel.Effect>
                 <Separator/>
-                <!--<ListBoxItem Margin="2,5" Style="{StaticResource MahApps.Styles.ListBoxItem.HamburgerMenuSeparator}"/>-->
                 <Label Content="Other" Margin="10,5" FontWeight="Bold"/>
                 <ListBox Name="IOtherMenuItems" HorizontalAlignment="Stretch" Margin="0,1">
                     <ToggleButton Name="navSettings" Style="{StaticResource MahApps.Styles.ToggleButton.WindowCommands}" Click="ToggleButton_Click">


### PR DESCRIPTION
Added scrollbar to Server Profiles list in MainWindow.xaml

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds a scrollbar to the Server Profiles list in MainWindow.xaml. Previously, if the list contained many profiles, some of them were not accessible because they were outside the visible area. This update ensures that all profiles can be seen and selected by adding a scrollable container.

## Motivation and Context
- This change is necessary because users with many server profiles were unable to access all of them without resizing the window.
- It improves usability by making all profiles visible in a structured and user-friendly way.
- This change does not alter the core functionality of the application but enhances the user interface.

## How Has This Been Tested?
- The modification was tested by compiling the project in Visual Studio.
- The application was run with different numbers of server profiles to verify that the scrollbar appears when necessary.
- No performance issues or visual bugs were detected.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/073d56cb-2c43-404a-aac5-b1de211de540)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
