### PR TITLE
Feature/server language

### DIFF
--- a/FASTER/Models/BasicCfg.cs
+++ b/FASTER/Models/BasicCfg.cs
@@ -30,6 +30,7 @@ namespace FASTER.Models
         private ushort maxPacketSize        = 1400;
 
         private string basicContent;
+        private string a3cfgContent;
 
         public string BasicContent
         {
@@ -38,6 +39,16 @@ namespace FASTER.Models
             {
                 basicContent = value;
                 RaisePropertyChanged("BasicContent");
+            }
+        }
+        
+        public string Arma3CfgContent
+        {
+            get => a3cfgContent;
+            set
+            {
+                a3cfgContent = value;
+                RaisePropertyChanged("Arma3CfgContent");
             }
         }
 
@@ -198,9 +209,12 @@ namespace FASTER.Models
         }
 
         public BasicCfg()
-        { BasicContent = ProcessFile(); }
+        { 
+            BasicContent = ProcessBasicFile();
+            Arma3CfgContent = ProcessArma3CfgFile();
+        }
 
-        public string ProcessFile()
+        public string ProcessBasicFile()
         {
             string output = "// These options are created by default\r\n"
                           + $"language=\"{language}\";\r\n"
@@ -229,6 +243,14 @@ namespace FASTER.Models
                           + $"class sockets{{ maxPacketSize = {maxPacketSize};}};";
             return output;
         }
+        
+        public string ProcessArma3CfgFile()
+        {
+            string output = "steamLanguage=\"\";\r\n"
+                    + $"language=\"{language}\";\r\n";
+
+            return output;
+        }
 
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -236,7 +258,11 @@ namespace FASTER.Models
         {
             if (PropertyChanged == null) return;
             PropertyChanged(this, new PropertyChangedEventArgs(property));
-            if (property != "BasicContent") BasicContent = ProcessFile();
+            if (property != "BasicContent" && property != "Arma3CfgContent")
+            {
+                BasicContent = ProcessBasicFile();
+                Arma3CfgContent = ProcessArma3CfgFile();
+            }
         }
     }
 }

--- a/FASTER/Models/BasicCfg.cs
+++ b/FASTER/Models/BasicCfg.cs
@@ -14,6 +14,8 @@ namespace FASTER.Models
     [Serializable]
     public class BasicCfg : INotifyPropertyChanged
     {
+        private string language     = "English";
+        
         private uint   viewDistance = 2000;
         private double terrainGrid  = 25;
 
@@ -39,6 +41,16 @@ namespace FASTER.Models
             }
         }
 
+        public string Language
+        {
+            get => language;
+            set
+            {
+                language = value;
+                RaisePropertyChanged("Language");
+            }
+        }
+        
         public uint ViewDistance
         {
             get => viewDistance;
@@ -191,7 +203,7 @@ namespace FASTER.Models
         public string ProcessFile()
         {
             string output = "// These options are created by default\r\n"
-                          + "language=\"English\";\r\n"
+                          + $"language=\"{language}\";\r\n"
                           + "adapter=-1;\r\n"
                           + "3D_Performance=1.000000;\r\n"
                           + "Resolution_W=800;\r\n"

--- a/FASTER/Models/ServerProfile.cs
+++ b/FASTER/Models/ServerProfile.cs
@@ -25,7 +25,8 @@ namespace FASTER.Models
             var currentProfiles = Properties.Settings.Default.Profiles;
             var p = new ServerProfile(profileName);
             p.ServerCfg.ServerCfgContent     = p.ServerCfg.ProcessFile();
-            p.BasicCfg.BasicContent          = p.BasicCfg.ProcessFile();
+            p.BasicCfg.BasicContent          = p.BasicCfg.ProcessBasicFile();
+            p.BasicCfg.Arma3CfgContent       = p.BasicCfg.ProcessArma3CfgFile();
             p.ArmaProfile.ArmaProfileContent = p.ArmaProfile.ProcessFile();
             currentProfiles.Add(p);
             Properties.Settings.Default.Profiles = currentProfiles;
@@ -428,7 +429,8 @@ namespace FASTER.Models
             BasicCfg = new BasicCfg();
             ServerCfg.ServerCfgContent = ServerCfg.ProcessFile();
             ArmaProfile.ArmaProfileContent = ArmaProfile.ProcessFile();
-            BasicCfg.BasicContent = BasicCfg.ProcessFile();
+            BasicCfg.BasicContent = BasicCfg.ProcessBasicFile();
+            BasicCfg.Arma3CfgContent = BasicCfg.ProcessArma3CfgFile();
 
             if (createFolder)
             { Directory.CreateDirectory(Path.Combine(Properties.Settings.Default.serverPath, "Servers", Id)); }
@@ -443,7 +445,8 @@ namespace FASTER.Models
             BasicCfg    = new BasicCfg();
             ServerCfg.ServerCfgContent = ServerCfg.ProcessFile();
             ArmaProfile.ArmaProfileContent = ArmaProfile.ProcessFile();
-            BasicCfg.BasicContent = BasicCfg.ProcessFile();
+            BasicCfg.BasicContent = BasicCfg.ProcessBasicFile();
+            BasicCfg.Arma3CfgContent = BasicCfg.ProcessArma3CfgFile();
         }
 
         public void GenerateNewId()

--- a/FASTER/ViewModel/ProfileViewModel.cs
+++ b/FASTER/ViewModel/ProfileViewModel.cs
@@ -212,9 +212,11 @@ namespace FASTER.ViewModel
             string config        = Path.Combine(Profile.ArmaPath, "Servers", Profile.Id, "server_config.cfg");
             string basic         = Path.Combine(Profile.ArmaPath, "Servers", Profile.Id, "server_basic.cfg");
             string serverProfile = Path.Combine(Profile.ArmaPath, "Servers", Profile.Id, "users", Profile.Id, $"{Profile.Id}.Arma3Profile");
+            string arma3Cfg      = Path.Combine(Profile.ArmaPath, "Servers", Profile.Id, "users", Environment.UserName, $"Arma3.cfg"); 
 
             //Creating profile directory
             Directory.CreateDirectory(Path.Combine(Profile.ArmaPath, "Servers", Profile.Id, "users", Profile.Id));
+            Directory.CreateDirectory(Path.Combine(Profile.ArmaPath, "Servers", Profile.Id, "users", Environment.UserName));
 
             //Writing files
             try
@@ -222,6 +224,7 @@ namespace FASTER.ViewModel
                 File.WriteAllLines(config,        Profile.ServerCfg.ServerCfgContent.Replace("\r", "").Split('\n'));
                 File.WriteAllLines(basic,         Profile.BasicCfg.BasicContent.Replace("\r", "").Split('\n'));
                 File.WriteAllLines(serverProfile, Profile.ArmaProfile.ArmaProfileContent.Replace("\r", "").Split('\n'));
+                File.WriteAllLines(arma3Cfg,      Profile.BasicCfg.Arma3CfgContent.Replace("\r", "").Split('\n'));
             }
             catch
             { DisplayMessage("Could not write the config files. Please ensure the server is not running and retry."); }

--- a/FASTER/Views/Profile.xaml
+++ b/FASTER/Views/Profile.xaml
@@ -58,7 +58,7 @@
                                     <Button Content="{iconPacks:Material Kind=FolderOpen}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Grid.Column="1" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}" Height="auto" Margin="5,5,0,5" Style="{StaticResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" Padding="3" Click="SelectServerFile"/>
                                 </Grid>
                                 <mah:NumericUpDown Value="{Binding Profile.Port, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="Port" ToolTip="Port for ArmaServer"/>
-                                <TextBox Text="{Binding Path=Profile.BasicCfg.Language, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.Watermark="Server Language" mah:TextBoxHelper.UseFloatingWatermark="True" />
+                                <TextBox Text="{Binding Path=Profile.BasicCfg.Language, UpdateSourceTrigger=PropertyChanged}" Margin="0 5" mah:TextBoxHelper.Watermark="Server Language" mah:TextBoxHelper.UseFloatingWatermark="True" />
                             </StackPanel>
                         </GroupBox>
                         <StackPanel Height="10"/>

--- a/FASTER/Views/Profile.xaml
+++ b/FASTER/Views/Profile.xaml
@@ -58,6 +58,7 @@
                                     <Button Content="{iconPacks:Material Kind=FolderOpen}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Grid.Column="1" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}" Height="auto" Margin="5,5,0,5" Style="{StaticResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" Padding="3" Click="SelectServerFile"/>
                                 </Grid>
                                 <mah:NumericUpDown Value="{Binding Profile.Port, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="Port" ToolTip="Port for ArmaServer"/>
+                                <TextBox Text="{Binding Path=Profile.BasicCfg.Language, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.Watermark="Server Language" mah:TextBoxHelper.UseFloatingWatermark="True" />
                             </StackPanel>
                         </GroupBox>
                         <StackPanel Height="10"/>
@@ -666,7 +667,7 @@
                                         <mah:NumericUpDown Value="{Binding Path=Profile.ServerCfg.SteamProtocolMaxDataSize}" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="Steam Protocol Max Data Size" Margin="5"/>
 
                                         <TextBox MinHeight="50" Margin="5" Text="{Binding Path=Profile.ServerCfg.Admins}" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="Admins IDs (one per line)"/>
-
+                                        
                                     </StackPanel>
                                 </Expander>
                             </StackPanel>

--- a/FASTERTests/Models/BasicCfgTests.cs
+++ b/FASTERTests/Models/BasicCfgTests.cs
@@ -30,6 +30,7 @@ namespace FASTER.Models.Tests
             Assert.That(_cfg.PerfPreset, Is.EqualTo("Custom"));
             Assert.That(_cfg.TerrainGrid, Is.Not.Null);
             Assert.That(_cfg.ViewDistance, Is.Not.Null);
+            Assert.That(_cfg.Language, Is.Not.Null);
         }
 
         [Test()]


### PR DESCRIPTION
*sry for my English, i use translator
## Description
I added the server language input string. Now you can enter your language, and the server will not start in English only.

## Motivation and Context
mission strings are loaded depending on the server language.
[issue](https://github.com/Foxlider/FASTER/issues/134)

## How Has This Been Tested?
I saved my profile and started the server by entering my native language in the field. The server started in the correct language. I also checked the configuration files - everything was written correctly.
I use Windows 11. I use Rider for development. 
I ran all the unit tests and they were green.

## Screenshots (if appropriate):
![изображение](https://github.com/user-attachments/assets/16fa3df8-30ed-4812-bbfc-c9bcf10474c4)
![изображение](https://github.com/user-attachments/assets/090e7dd5-50ed-4f6f-a6b6-77d922d1e748)
![изображение](https://github.com/user-attachments/assets/4e38a578-de5f-4022-a62d-0081d6fdee53)


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
