### PR TITLE
Fix for Performance preset for server profiles not copied over

### DIFF
--- a/FASTER Maintenance/Models/BasicCfg.cs
+++ b/FASTER Maintenance/Models/BasicCfg.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Globalization;
+using Newtonsoft.Json;
 
 // ReSharper disable once CheckNamespace
 namespace FASTER.Models
@@ -125,6 +126,7 @@ namespace FASTER.Models
             }
         }
 
+        [JsonIgnore]
         public string PerfPreset
         {
             get => "Custom";

--- a/FASTER/Models/BasicCfg.cs
+++ b/FASTER/Models/BasicCfg.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
 
 namespace FASTER.Models
 {
@@ -150,6 +151,7 @@ namespace FASTER.Models
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public string PerfPreset
         {
             get => "Custom";


### PR DESCRIPTION
Fix for Performance preset for server profiles not copied over

## Description
Fixes this issue
https://github.com/Foxlider/FASTER/issues/251

## Motivation and Context
So the Performance tab is correctly copied