### PR TITLE
Changing CheckForUpdates to cope with larger mod lists

### DIFF
--- a/FASTER/ViewModel/ModsViewModel.cs
+++ b/FASTER/ViewModel/ModsViewModel.cs
@@ -230,10 +230,14 @@ namespace FASTER.ViewModel
 
             Process.Start(startInfo);
         }
-        public void CheckForUpdates()
+        
+        public async Task CheckForUpdates()
         {
             foreach (ArmaMod mod in ModsCollection.ArmaMods)
-            { Task.Run(() => mod.UpdateInfos()); }
+            {
+                Task.Run(() => mod.UpdateInfos());
+                await Task.Delay(300); // Throttle to avoid API spamming
+            }
         }
 
         public async Task UpdateSelectedMods()

--- a/FASTER/Views/Mods.xaml.cs
+++ b/FASTER/Views/Mods.xaml.cs
@@ -72,9 +72,9 @@ namespace FASTER.Views
             await ((ModsViewModel)DataContext)?.OpenLauncherFile();
         }
 
-        private void CheckForUpdates_Click(object sender, RoutedEventArgs e)
+        private async void CheckForUpdates_Click(object sender, RoutedEventArgs e)
         {
-            ((ModsViewModel) DataContext)?.CheckForUpdates();
+            await ((ModsViewModel) DataContext)?.CheckForUpdates();
         }
 
         private void UpdateAll_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Description, Motivation and Context
I was encountering issues with larger mod lists in which the client would not fetch down mod data. The Steam API was presumably throttling the requests as they were all being sent at once and therefore no mod data was being updated.

The Steam API does support a multi id information request but this solution was much faster to implement as a fix for now, it can be re-visited if needed at a later date. The delay timer could potentially be tweaked and lowered but this value worked on for me fine.

This issue has been raised in the discord a couple of times by different people.

## How Has This Been Tested?
Release version built and used on my dedicated server, mod information fetched down fine no issues. The functionality itself has not changed therefore the unit changes do not need to be modified and all pass.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
