### PR TITLE
feat: resolve 9 bugs, integrate 6 PRs, add 5 features + debug logging (v2.0.0.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore FASTER.sln
+
+      - name: Build
+        run: dotnet build FASTER.sln --configuration Release --no-restore

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,9 @@ on:
     branches: [ master ]
   workflow_dispatch: # CodeQL can be triggered manually
 
+env:
+  DOTNET_VERSION: '8.0.x'
+
 jobs:
   analyzeQL:
     name: Analyze with CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,8 @@ jobs:
   release:
     needs: build
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
 
     - name: Checkout
@@ -158,10 +160,16 @@ jobs:
           $changes = $changes -replace "^(.*)$", "$linePrefix`$1"
         }
 
+        # Truncate changelog to avoid exceeding env var limits (max ~32k)
+        $changesStr = $changes -join "`n"
+        if ($changesStr.Length -gt 20000) {
+          $changesStr = $changesStr.Substring(0, 20000) + "`n...(truncated)"
+        }
+
         # Set outputs
         $EOF = (New-Guid).Guid
         "changes<<$EOF" >> $env:GITHUB_OUTPUT
-        $changes >> $env:GITHUB_OUTPUT
+        $changesStr >> $env:GITHUB_OUTPUT
         "$EOF" >> $env:GITHUB_OUTPUT
         "tag=$latestTag" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,14 @@ name: "Release Generator"
 
 # after successful analysis on the main branch, a new pre-release is generated
 on:
-  #Makes a Nighly release on a new commit. 
+  #Makes a Nightly release after a successful build on master
   workflow_run:
-    workflows: [Code Analysis]
+    workflows: [Build]
     types: [completed]
     branches: [master]
-  
+
   #Makes a Release on tag
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
   workflow_dispatch: # ReleaseGen can be triggered manually
@@ -25,7 +24,7 @@ jobs:
 
   # BUILD APP
   build:
-    if: ( github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' ) || startsWith(github.ref, 'refs/tags/v')
+    if: ( github.event.workflow_run.conclusion == 'success' ) || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         # runtime: [x64, x86]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
   workflow_dispatch: # ReleaseGen can be triggered manually
 
 env:
+  DOTNET_VERSION: '8.0.x'
   IS_RELEASE: ${{ github.ref_type == 'tag' }}
   ZIP_NAME: ${{ github.ref_type == 'tag' && 'Release_' || 'Release_Nightly_' }}
   ZIP_PATH: ${{ github.ref_type == 'tag' && 'FASTER_' || 'FASTER_Nightly_' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,8 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         tag_name: nightly
-        name: 'Nightly Release v${{ env.VERSION }}'
+        name: 'FASTER Nightly v${{ env.VERSION }}'
+        draft: false
         body: |
           Changelog since release ${{ steps.get-changes.outputs.tag }} :
           ---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 env:
   DOTNET_VERSION: '8.0.x'
   IS_RELEASE: ${{ github.ref_type == 'tag' }}
-  ZIP_NAME: ${{ github.ref_type == 'tag' && 'Release_' || 'Release_Nightly_' }}
+  ZIP_NAME: ${{ github.ref_type == 'tag' && 'Release_' || 'FASTER_' }}
   ZIP_PATH: ${{ github.ref_type == 'tag' && 'FASTER_' || 'FASTER_Nightly_' }}
 
 jobs:
@@ -246,5 +246,5 @@ jobs:
           ---
           ${{ steps.get-changes.outputs.changes }}
           ---
-        prerelease: true
+        prerelease: false
         files: ./artifacts/${{ env.ZIP_NAME}}x64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         tag_name: nightly
-        name: 'FASTER Nightly v${{ env.VERSION }}'
+        name: 'FASTER v${{ env.VERSION }}'
         draft: false
         body: |
           Changelog since release ${{ steps.get-changes.outputs.tag }} :

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,12 +223,14 @@ jobs:
         asset_name: ${{ env.ZIP_NAME}}x64.zip
         asset_content_type: application/zip
     
-    # Delete existing nightly tag so it can be recreated
-    - name: Delete existing nightly tag
+    # Delete existing nightly release and tag so it can be recreated cleanly
+    - name: Delete existing nightly release and tag
       if: env.IS_RELEASE == 'false'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        gh release delete nightly --yes --repo ${{ github.repository }} || true
         git push origin :refs/tags/nightly || true
-        git tag -d nightly || true
       shell: bash
 
     # Create Nightly Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,19 +224,25 @@ jobs:
         asset_name: ${{ env.ZIP_NAME}}x64.zip
         asset_content_type: application/zip
     
+    # Delete existing nightly tag so it can be recreated
+    - name: Delete existing nightly tag
+      if: env.IS_RELEASE == 'false'
+      run: |
+        git push origin :refs/tags/nightly || true
+        git tag -d nightly || true
+      shell: bash
+
     # Create Nightly Release
     - name: Create Nightly Release
       if: env.IS_RELEASE == 'false'
-      uses: andelf/nightly-release@main
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: nightly
         name: 'Nightly Release v${{ env.VERSION }}'
-        body: | 
-          Changelog since release ${{ steps.get-changes.outputs.tag }} :  
-          ---  
+        body: |
+          Changelog since release ${{ steps.get-changes.outputs.tag }} :
+          ---
           ${{ steps.get-changes.outputs.changes }}
-          ---  
+          ---
         prerelease: true
         files: ./artifacts/${{ env.ZIP_NAME}}x64.zip

--- a/FASTER/FASTER.csproj
+++ b/FASTER/FASTER.csproj
@@ -11,7 +11,7 @@
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>FASTERKey.snk</AssemblyOriginatorKeyFile>
         <Authors>Keelah Fox, Jupster, Canno.n</Authors>
-        <Version>1.9.7.2</Version>
+        <Version>1.9.7.3</Version>
         <Company>FoxliCorp.</Company>
         <Description>Fox's Arma Server Tool Extended Rewrite</Description>
         <Copyright>Copyright © 2019</Copyright>

--- a/FASTER/FASTER.csproj
+++ b/FASTER/FASTER.csproj
@@ -11,7 +11,7 @@
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>FASTERKey.snk</AssemblyOriginatorKeyFile>
         <Authors>Keelah Fox, Jupster, Canno.n</Authors>
-        <Version>1.9.7.3</Version>
+        <Version>2.0.0.0</Version>
         <Company>FoxliCorp.</Company>
         <Description>Fox's Arma Server Tool Extended Rewrite</Description>
         <Copyright>Copyright © 2019</Copyright>

--- a/FASTER/MainWindow.xaml.cs
+++ b/FASTER/MainWindow.xaml.cs
@@ -165,11 +165,27 @@ namespace FASTER
             Application.Current.Shutdown();
         }
 
+        private static IEnumerable<ToggleButton> GetProfileToggleButtons(System.Windows.Controls.ListBox menu)
+        {
+            foreach (var item in menu.Items)
+            {
+                if (item is System.Windows.Controls.DockPanel dp)
+                {
+                    var tb = dp.Children.OfType<ToggleButton>().FirstOrDefault();
+                    if (tb != null) yield return tb;
+                }
+                else if (item is ToggleButton t)
+                {
+                    yield return t;
+                }
+            }
+        }
+
         private void ToggleButton_Click(object sender, RoutedEventArgs e)
         {
             var list = new List<ToggleButton>();
             list.AddRange(IMainMenuItems.Items.Cast<ToggleButton>().Where(i => i.IsChecked == true));
-            list.AddRange(IServerProfilesMenu.Items.Cast<ToggleButton>().Where(i => i.IsChecked == true));
+            list.AddRange(GetProfileToggleButtons(IServerProfilesMenu).Where(i => i.IsChecked == true));
             list.AddRange(IOtherMenuItems.Items.Cast<ToggleButton>().Where(i => i.IsChecked == true));
 
             if (sender is not ToggleButton nav || !NavEnabled) return;
@@ -177,13 +193,13 @@ namespace FASTER
             //Don't navigate if same menu is clicked
             if (nav == lastNavButton) return;
 
-            
+
 
             //Clear selected Buttons
             IServerProfilesMenu.SelectedItem = null;
             foreach (var item in list.Where(item => item.Name != nav.Name))
             { item.IsChecked = false; }
-                
+
             nav.IsChecked = true;
             lastNavButton = nav;
 
@@ -216,7 +232,7 @@ namespace FASTER
                     MainContent.Content = ContentAbout;
                     break;
                 default:
-                    if (IServerProfilesMenu.Items.Cast<ToggleButton>().FirstOrDefault(p => p.Name == nav.Name) != null)
+                    if (GetProfileToggleButtons(IServerProfilesMenu).FirstOrDefault(p => p.Name == nav.Name) != null)
                     {
                         var profile = new Profile();
                         MainContent.Content = profile;
@@ -259,6 +275,14 @@ namespace FASTER
             }
         }
 
+        private ToggleButton GetSelectedProfileToggleButton()
+        {
+            var selected = IServerProfilesMenu.SelectedItem;
+            if (selected is System.Windows.Controls.DockPanel dp)
+                return dp.Children.OfType<ToggleButton>().FirstOrDefault();
+            return selected as ToggleButton;
+        }
+
         private void MenuItemClone_Click(object sender, RoutedEventArgs e)
         {
             if (IServerProfilesMenu.SelectedIndex == -1)
@@ -266,15 +290,16 @@ namespace FASTER
 
             try
             {
+                var selectedBtn = GetSelectedProfileToggleButton();
                 var temp = Properties.Settings.Default.Profiles.FirstOrDefault(s =>
-                    s.Id == ((ToggleButton) IServerProfilesMenu.SelectedItem).Name);
+                    s.Id == selectedBtn?.Name);
                 if (temp == null)
                 {
                     DisplayMessage("Could not find the selected profile.");
                     return;
                 }
 
-                ServerProfile serverProfile = temp.Clone(); 
+                ServerProfile serverProfile = temp.Clone();
                 ServerProfileCollection.AddServerProfile(serverProfile);
             }
             catch (Exception err)
@@ -291,8 +316,9 @@ namespace FASTER
 
             try
             {
+                var selectedBtn = GetSelectedProfileToggleButton();
                 var temp = Properties.Settings.Default.Profiles.FirstOrDefault(s =>
-                    s.Id == ((ToggleButton)IServerProfilesMenu.SelectedItem).Name);
+                    s.Id == selectedBtn?.Name);
                 if (temp == null)
                 {
                     DisplayMessage("Could not find the selected profile.");
@@ -435,16 +461,86 @@ namespace FASTER
                     HorizontalContentAlignment = HorizontalAlignment.Left,
                 };
                 newItem.SetValue(TextOptions.TextFormattingModeProperty, TextFormattingMode.Display);
-                Dispatcher?.Invoke(() => { IServerProfilesMenu.Items.Add(newItem); });
+
+                var profileId = profile.Id;
+
+                var btnUp = new System.Windows.Controls.Button
+                {
+                    Content = "▲",
+                    FontSize = 10,
+                    Width = 18,
+                    Height = 18,
+                    Padding = new Thickness(0),
+                    Margin = new Thickness(0, 0, 1, 0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Style = (Style)FindResource("MahApps.Styles.Button.MetroSquare"),
+                    BorderThickness = new Thickness(0),
+                    ToolTip = "Move Up",
+                };
+                btnUp.Click += (s, e) => { e.Handled = true; MoveProfileUp(profileId); };
+
+                var btnDown = new System.Windows.Controls.Button
+                {
+                    Content = "▼",
+                    FontSize = 10,
+                    Width = 18,
+                    Height = 18,
+                    Padding = new Thickness(0),
+                    Margin = new Thickness(0, 0, 2, 0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Style = (Style)FindResource("MahApps.Styles.Button.MetroSquare"),
+                    BorderThickness = new Thickness(0),
+                    ToolTip = "Move Down",
+                };
+                btnDown.Click += (s, e) => { e.Handled = true; MoveProfileDown(profileId); };
+
+                var rowPanel = new System.Windows.Controls.DockPanel
+                {
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    LastChildFill = true,
+                };
+                System.Windows.Controls.DockPanel.SetDock(btnUp,   System.Windows.Controls.Dock.Right);
+                System.Windows.Controls.DockPanel.SetDock(btnDown, System.Windows.Controls.Dock.Right);
+                rowPanel.Children.Add(btnDown);
+                rowPanel.Children.Add(btnUp);
+                rowPanel.Children.Add(newItem);
+
+                Dispatcher?.Invoke(() => { IServerProfilesMenu.Items.Add(rowPanel); });
 
                 newItem.Click += ToggleButton_Click;
 
-                if (ContentProfileViews.Any(tab => profile.Id == tab.Profile.Id)) 
+                if (ContentProfileViews.Any(tab => profile.Id == tab.Profile.Id))
                     continue;
 
                 var p = new ProfileViewModel(profile);
                 ContentProfileViews.Add(p);
             }
+        }
+
+        private void MoveProfileUp(string profileId)
+        {
+            var profiles = Properties.Settings.Default.Profiles;
+            int idx = profiles.FindIndex(p => p.Id == profileId);
+            if (idx <= 0) return;
+            var item = profiles[idx];
+            profiles.RemoveAt(idx);
+            profiles.Insert(idx - 1, item);
+            Properties.Settings.Default.Profiles = profiles;
+            Properties.Settings.Default.Save();
+            LoadServerProfiles();
+        }
+
+        private void MoveProfileDown(string profileId)
+        {
+            var profiles = Properties.Settings.Default.Profiles;
+            int idx = profiles.FindIndex(p => p.Id == profileId);
+            if (idx < 0 || idx >= profiles.Count - 1) return;
+            var item = profiles[idx];
+            profiles.RemoveAt(idx);
+            profiles.Insert(idx + 1, item);
+            Properties.Settings.Default.Profiles = profiles;
+            Properties.Settings.Default.Save();
+            LoadServerProfiles();
         }
 
         private async Task ModConversion()

--- a/FASTER/Models/ArmaMod.cs
+++ b/FASTER/Models/ArmaMod.cs
@@ -105,6 +105,7 @@ namespace FASTER.Models
         private long   _size;
         private bool   _isLoading;
         private bool   _isSelected;
+        private static bool _apiKeyWarningShown = false;
 
 
         public uint   WorkshopId
@@ -336,6 +337,13 @@ namespace FASTER.Models
                     Status = ArmaModStatus.UpToDate;
                 success = true;
             } while (failNum < 3 && !success);
+
+            if (!success && !_apiKeyWarningShown)
+            {
+                _apiKeyWarningShown = true;
+                MainWindow.Instance?.Dispatcher.Invoke(() =>
+                    MainWindow.Instance.DisplayMessage("Could not fetch mod info. Please check your Steam API Key in Settings."));
+            }
 
             if (checkFileSize)
                 CheckModSize();

--- a/FASTER/Models/BasicCfg.cs
+++ b/FASTER/Models/BasicCfg.cs
@@ -9,6 +9,7 @@ namespace FASTER.Models
     {
         public static string[] PerfPresets { get; } = {"Custom", "Arma3 Defaults", "1Mb Preset", "250Mb Preset", "1Gb Preset"};
         public static double[] TerrainGrids { get; } = { 50, 25, 12.5, 6.25, 3.125 };
+        public static string[] Languages { get; } = { "English", "Czech", "French", "German", "Italian", "Polish", "Portuguese", "Russian", "Spanish", "Turkish", "Hungarian" };
     }
 
     [Serializable]
@@ -27,7 +28,18 @@ namespace FASTER.Models
         private ushort maxCustomFileSize    = 1024;
         private ushort maxPacketSize        = 1400;
 
+        private string _language = "English";
         private string basicContent;
+
+        public string Language
+        {
+            get => _language;
+            set
+            {
+                _language = value;
+                RaisePropertyChanged(nameof(Language));
+            }
+        }
 
         public string BasicContent
         {
@@ -35,7 +47,7 @@ namespace FASTER.Models
             set
             {
                 basicContent = value;
-                RaisePropertyChanged("BasicContent");
+                RaisePropertyChanged(nameof(BasicContent));
             }
         }
 
@@ -45,7 +57,7 @@ namespace FASTER.Models
             set
             {
                 viewDistance = value;
-                RaisePropertyChanged("ViewDistance");
+                RaisePropertyChanged(nameof(ViewDistance));
             }
         }
 
@@ -55,7 +67,7 @@ namespace FASTER.Models
             set
             {
                 terrainGrid = value;
-                RaisePropertyChanged("TerrainGrid");
+                RaisePropertyChanged(nameof(TerrainGrid));
             }
         }
 
@@ -65,7 +77,7 @@ namespace FASTER.Models
             set
             {
                 maxSizeGuaranteed = value;
-                RaisePropertyChanged("MaxSizeGuaranteed");
+                RaisePropertyChanged(nameof(MaxSizeGuaranteed));
             }
         }
 
@@ -75,7 +87,7 @@ namespace FASTER.Models
             set
             {
                 maxSizeNonguaranteed = value;
-                RaisePropertyChanged("MaxSizeNonGuaranteed");
+                RaisePropertyChanged(nameof(MaxSizeNonGuaranteed));
             }
         }
 
@@ -85,7 +97,7 @@ namespace FASTER.Models
             set
             {
                 maxMsgSend = value;
-                RaisePropertyChanged("MaxMsgSend");
+                RaisePropertyChanged(nameof(MaxMsgSend));
             }
         }
 
@@ -95,7 +107,7 @@ namespace FASTER.Models
             set
             {
                 minBandwidth = value;
-                RaisePropertyChanged("MinBandwidth");
+                RaisePropertyChanged(nameof(MinBandwidth));
             }
         }
 
@@ -105,7 +117,7 @@ namespace FASTER.Models
             set
             {
                 maxBandwidth = value;
-                RaisePropertyChanged("MaxBandwidth");
+                RaisePropertyChanged(nameof(MaxBandwidth));
             }
         }
 
@@ -115,7 +127,7 @@ namespace FASTER.Models
             set
             {
                 maxPacketSize = value;
-                RaisePropertyChanged("MaxPacketSize");
+                RaisePropertyChanged(nameof(MaxPacketSize));
             }
         }
 
@@ -125,7 +137,7 @@ namespace FASTER.Models
             set
             {
                 minErrorToSend = value;
-                RaisePropertyChanged("MinErrorToSend");
+                RaisePropertyChanged(nameof(MinErrorToSend));
             }
         }
 
@@ -135,7 +147,7 @@ namespace FASTER.Models
             set
             {
                 minErrorToSendNear = value;
-                RaisePropertyChanged("MinErrorToSendNear");
+                RaisePropertyChanged(nameof(MinErrorToSendNear));
             }
         }
 
@@ -145,11 +157,12 @@ namespace FASTER.Models
             set
             {
                 maxCustomFileSize = value;
-                RaisePropertyChanged("MaxCustomFileSize");
+                RaisePropertyChanged(nameof(MaxCustomFileSize));
             }
         }
 
         [XmlIgnore]
+        [Newtonsoft.Json.JsonIgnore]
         public string PerfPreset
         {
             get => "Custom";
@@ -181,7 +194,7 @@ namespace FASTER.Models
                         MinBandwidth         = 1000000000;
                         break;
                 }
-                RaisePropertyChanged("PerfPreset");
+                RaisePropertyChanged(nameof(PerfPreset));
             }
         }
 
@@ -191,7 +204,7 @@ namespace FASTER.Models
         public string ProcessFile()
         {
             string output = "// These options are created by default\r\n"
-                          + "language=\"English\";\r\n"
+                          + $"language=\"{_language}\";\r\n"
                           + "adapter=-1;\r\n"
                           + "3D_Performance=1.000000;\r\n"
                           + "Resolution_W=800;\r\n"

--- a/FASTER/Models/Logger.cs
+++ b/FASTER/Models/Logger.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+
+namespace FASTER.Models
+{
+    public static class Logger
+    {
+        private static readonly string LogPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "FASTER", "faster.log");
+
+        public static bool IsEnabled => Properties.Settings.Default.enableDebugLog;
+
+        public static string LogFilePath => LogPath;
+
+        public static void Log(string message)
+        {
+            if (!IsEnabled) return;
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(LogPath)!);
+                File.AppendAllText(LogPath, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {message}{Environment.NewLine}");
+            }
+            catch { }
+        }
+    }
+}

--- a/FASTER/Models/ServerCfg.cs
+++ b/FASTER/Models/ServerCfg.cs
@@ -560,7 +560,7 @@ namespace FASTER.Models
             set
             {
                 drawingInMap = value;
-                RaisePropertyChanged(nameof(DrawinginMap));
+                RaisePropertyChanged(nameof(DrawingInMap));
             }
         }
 

--- a/FASTER/Models/ServerCfg.cs
+++ b/FASTER/Models/ServerCfg.cs
@@ -50,8 +50,8 @@ namespace FASTER.Models
         private int    roleTimeOut              = 90; 	 	 // <- These are BI base figues
         private int    votingTimeOut            = 60; 	 	 // <-
         private int    debriefingTimeOut        = 45;        // <-
-        private bool   LogObjectNotFound        = true;      // logging enabled
-        private bool   SkipDescriptionParsing   = false;     // parse description.ext
+        private bool   _logObjectNotFound        = true;      // logging enabled
+        private bool   _skipDescriptionParsing   = false;     // parse description.ext
         private bool   ignoreMissionLoadErrors  = false;     // do not ingore errors
         private int    armaUnitsTimeout         = 30; 	     // Defines how long the player will be stuck connecting and wait for armaUnits data. Player will be notified if timeout elapsed and no units data was received
         private int    queueSizeLogG            = 1000000; 	 // if a specific players message queue is larger than 1MB and '#monitor' is running, dump his messages to a logfile for analysis
@@ -88,6 +88,14 @@ namespace FASTER.Models
         private List<ProfileMission> _missions = new();
         private bool                 autoInit;
         private string               difficulty = "Custom";
+        private string               _missionHTTPDownloadBaseURL = "";
+
+        // AntiFlood (Arma 2.18+)
+        private bool _antiFloodEnabled        = false;
+        private int  _antiFloodCycleTime      = 5;
+        private int  _antiFloodCycleLimit     = 5;
+        private int  _antiFloodCycleHardLimit = 10;
+        private int  _antiFloodEnableKick     = 0;  // 0 = disabled, 1 = enabled
 
         private bool   maxMemOverride;
         private uint   maxMem = 1024;
@@ -106,7 +114,7 @@ namespace FASTER.Models
             set
             {
                 passwordAdmin = value;
-                RaisePropertyChanged("PasswordAdmin");
+                RaisePropertyChanged(nameof(PasswordAdmin));
             }
         }
 
@@ -116,7 +124,7 @@ namespace FASTER.Models
             set
             {
                 password = value;
-                RaisePropertyChanged("Password");
+                RaisePropertyChanged(nameof(Password));
             }
         }
 
@@ -126,7 +134,7 @@ namespace FASTER.Models
             set
             {
                 serverCommandPassword = value;
-                RaisePropertyChanged("ServerCommandPassword");
+                RaisePropertyChanged(nameof(ServerCommandPassword));
             }
         }
 
@@ -136,7 +144,7 @@ namespace FASTER.Models
             set
             {
                 hostname = value;
-                RaisePropertyChanged("Hostname");
+                RaisePropertyChanged(nameof(Hostname));
             }
         }
 
@@ -146,7 +154,7 @@ namespace FASTER.Models
             set
             {
                 maxPlayers = value;
-                RaisePropertyChanged("MaxPlayers");
+                RaisePropertyChanged(nameof(MaxPlayers));
             }
         }
 
@@ -156,7 +164,7 @@ namespace FASTER.Models
             set
             {
                 motd = value.Replace("\r", "").Split('\n').ToList();
-                RaisePropertyChanged("Motd");
+                RaisePropertyChanged(nameof(Motd));
             }
         }
 
@@ -166,7 +174,7 @@ namespace FASTER.Models
             set
             {
                 motdInterval = value;
-                RaisePropertyChanged("MotdInterval");
+                RaisePropertyChanged(nameof(MotdInterval));
             }
         }
 
@@ -176,7 +184,7 @@ namespace FASTER.Models
             set
             {
                 admins = value.Replace("\r", "").Split('\n').ToList();
-                RaisePropertyChanged("Admins");
+                RaisePropertyChanged(nameof(Admins));
             }
         }
 
@@ -186,7 +194,7 @@ namespace FASTER.Models
             set
             {
                 headlessClients = value.Replace("\r", "").Split('\n').ToList();
-                RaisePropertyChanged("HeadlessClients");
+                RaisePropertyChanged(nameof(HeadlessClients));
             }
         }
 
@@ -196,7 +204,7 @@ namespace FASTER.Models
             set
             {
                 localClient = value.Split('\n').ToList();
-                RaisePropertyChanged("LocalClient");
+                RaisePropertyChanged(nameof(LocalClient));
             }
         }
 
@@ -206,7 +214,7 @@ namespace FASTER.Models
             set
             {
                 headlessClientEnabled = value;
-                RaisePropertyChanged("HeadlessClientEnabled");
+                RaisePropertyChanged(nameof(HeadlessClientEnabled));
                 if (value && !headlessClients.Exists(e => e.Length > 0))
                 { HeadlessClients = "127.0.0.1"; }
             }
@@ -218,7 +226,7 @@ namespace FASTER.Models
             set
             {
                 votingEnabled = value;
-                RaisePropertyChanged("VotingEnabled");
+                RaisePropertyChanged(nameof(VotingEnabled));
             }
         }
 
@@ -228,7 +236,7 @@ namespace FASTER.Models
             set
             {
                 netlogEnabled = value;
-                RaisePropertyChanged("NetLogEnabled");
+                RaisePropertyChanged(nameof(NetLogEnabled));
             }
         }
         #endregion
@@ -240,7 +248,7 @@ namespace FASTER.Models
             set
             {
                 voteThreshold = value;
-                RaisePropertyChanged("VoteThreshold");
+                RaisePropertyChanged(nameof(VoteThreshold));
             }
         }
 
@@ -250,7 +258,7 @@ namespace FASTER.Models
             set
             {
                 voteMissionPlayers = value;
-                RaisePropertyChanged("VoteMissionPlayers");
+                RaisePropertyChanged(nameof(VoteMissionPlayers));
             }
         }
 
@@ -260,7 +268,7 @@ namespace FASTER.Models
             set
             {
                 kickduplicate = value ? (short)1 : (short)0;
-                RaisePropertyChanged("KickDuplicates");
+                RaisePropertyChanged(nameof(KickDuplicates));
             }
         }
 
@@ -270,7 +278,7 @@ namespace FASTER.Models
             set
             {
                 loopback = value;
-                RaisePropertyChanged("Loopback");
+                RaisePropertyChanged(nameof(Loopback));
             }
         }
 
@@ -280,7 +288,7 @@ namespace FASTER.Models
             set
             {
                 upnp = value;
-                RaisePropertyChanged("Upnp");
+                RaisePropertyChanged(nameof(Upnp));
             }
         }
 
@@ -290,7 +298,7 @@ namespace FASTER.Models
             set
             {
                 allowedFilePatching = (short)Array.IndexOf(ServerCfgArrays.AllowFilePatchingStrings, value);
-                RaisePropertyChanged("Password");
+                RaisePropertyChanged(nameof(AllowedFilePatching));
             }
         }
 
@@ -300,7 +308,7 @@ namespace FASTER.Models
             set
             {
                 disconnectTimeout = value;
-                RaisePropertyChanged("DisconnectTimeout");
+                RaisePropertyChanged(nameof(DisconnectTimeout));
             }
         }
 
@@ -310,7 +318,7 @@ namespace FASTER.Models
             set
             {
                 maxdesync = value;
-                RaisePropertyChanged("MaxDesync");
+                RaisePropertyChanged(nameof(MaxDesync));
             }
         }
 
@@ -320,7 +328,7 @@ namespace FASTER.Models
             set
             {
                 maxping = value;
-                RaisePropertyChanged("MaxPing");
+                RaisePropertyChanged(nameof(MaxPing));
             }
         }
 
@@ -330,7 +338,7 @@ namespace FASTER.Models
             set
             {
                 maxpacketloss = value;
-                RaisePropertyChanged("MaxPacketLoss");
+                RaisePropertyChanged(nameof(MaxPacketLoss));
             }
         }
 
@@ -340,7 +348,7 @@ namespace FASTER.Models
             set
             {
                 kickClientOnSlowNetwork = value;
-                RaisePropertyChanged("KickClientOnSlowNetwork");
+                RaisePropertyChanged(nameof(KickClientOnSlowNetwork));
             }
         }
 
@@ -350,7 +358,7 @@ namespace FASTER.Models
             set
             {
                 lobbyIdleTimeout = value;
-                RaisePropertyChanged("LobbyIdleTimeout");
+                RaisePropertyChanged(nameof(LobbyIdleTimeout));
             }
         }
 
@@ -360,7 +368,7 @@ namespace FASTER.Models
             set
             {
                 briefingTimeOut = value;
-                RaisePropertyChanged("BriefingTimeOut");
+                RaisePropertyChanged(nameof(BriefingTimeOut));
             }
         }
 
@@ -370,7 +378,7 @@ namespace FASTER.Models
             set
             {
                 roleTimeOut = value;
-                RaisePropertyChanged("RoleTimeOut");
+                RaisePropertyChanged(nameof(RoleTimeOut));
             }
         }
 
@@ -380,7 +388,7 @@ namespace FASTER.Models
             set
             {
                 votingTimeOut = value;
-                RaisePropertyChanged("VotingTimeOut");
+                RaisePropertyChanged(nameof(VotingTimeOut));
             }
         }
 
@@ -390,27 +398,27 @@ namespace FASTER.Models
             set
             {
                 debriefingTimeOut = value;
-                RaisePropertyChanged("DebriefingTimeOut");
+                RaisePropertyChanged(nameof(DebriefingTimeOut));
             }
         }
 
         public bool logObjectNotFound
         {
-            get => LogObjectNotFound;
+            get => _logObjectNotFound;
             set
             {
-                LogObjectNotFound = value;
-                RaisePropertyChanged("logObjectNotFound");
+                _logObjectNotFound = value;
+                RaisePropertyChanged(nameof(logObjectNotFound));
             }
         }
 
         public bool skipDescriptionParsing
         {
-            get => SkipDescriptionParsing;
+            get => _skipDescriptionParsing;
             set
             {
-                SkipDescriptionParsing = value;
-                RaisePropertyChanged("skipDescriptionParsing");
+                _skipDescriptionParsing = value;
+                RaisePropertyChanged(nameof(skipDescriptionParsing));
             }
         }
 
@@ -420,7 +428,7 @@ namespace FASTER.Models
             set
             {
                 ignoreMissionLoadErrors = value;
-                RaisePropertyChanged("IgnoreMissionLoadErrors");
+                RaisePropertyChanged(nameof(IgnoreMissionLoadErrors));
             }
         }
 
@@ -430,7 +438,7 @@ namespace FASTER.Models
             set
             {
                 armaUnitsTimeout = value;
-                RaisePropertyChanged("ArmaUnitsTimeout");
+                RaisePropertyChanged(nameof(ArmaUnitsTimeout));
             }
         }
 
@@ -440,7 +448,7 @@ namespace FASTER.Models
             set
             {
                 queueSizeLogG = value;
-                RaisePropertyChanged("QueueSizeLogG");
+                RaisePropertyChanged(nameof(QueueSizeLogG));
             }
         }
 
@@ -450,7 +458,7 @@ namespace FASTER.Models
             set
             {
                 forcedDifficulty = value;
-                RaisePropertyChanged("ForcedDifficulty");
+                RaisePropertyChanged(nameof(ForcedDifficulty));
             }
         }
 
@@ -460,7 +468,7 @@ namespace FASTER.Models
             set
             {
                 autoSelectMission = value;
-                RaisePropertyChanged("AutoSelectMission");
+                RaisePropertyChanged(nameof(AutoSelectMission));
             }
         }
 
@@ -470,7 +478,67 @@ namespace FASTER.Models
             set
             {
                 randomMissionOrder = value;
-                RaisePropertyChanged("RandomMissionOrder");
+                RaisePropertyChanged(nameof(RandomMissionOrder));
+            }
+        }
+
+        public string MissionHTTPDownloadBaseURL
+        {
+            get => _missionHTTPDownloadBaseURL;
+            set
+            {
+                _missionHTTPDownloadBaseURL = value;
+                RaisePropertyChanged(nameof(MissionHTTPDownloadBaseURL));
+            }
+        }
+
+        public bool AntiFloodEnabled
+        {
+            get => _antiFloodEnabled;
+            set
+            {
+                _antiFloodEnabled = value;
+                RaisePropertyChanged(nameof(AntiFloodEnabled));
+            }
+        }
+
+        public int AntiFloodCycleTime
+        {
+            get => _antiFloodCycleTime;
+            set
+            {
+                _antiFloodCycleTime = value;
+                RaisePropertyChanged(nameof(AntiFloodCycleTime));
+            }
+        }
+
+        public int AntiFloodCycleLimit
+        {
+            get => _antiFloodCycleLimit;
+            set
+            {
+                _antiFloodCycleLimit = value;
+                RaisePropertyChanged(nameof(AntiFloodCycleLimit));
+            }
+        }
+
+        public int AntiFloodCycleHardLimit
+        {
+            get => _antiFloodCycleHardLimit;
+            set
+            {
+                _antiFloodCycleHardLimit = value;
+                RaisePropertyChanged(nameof(AntiFloodCycleHardLimit));
+            }
+        }
+
+        public bool AntiFloodEnableKick
+        {
+            get => _antiFloodEnableKick == 1;
+            set
+            {
+                _antiFloodEnableKick = value ? 1 : 0;
+                RaisePropertyChanged(nameof(AntiFloodEnableKick));
             }
         }
         #endregion
@@ -482,7 +550,7 @@ namespace FASTER.Models
             set
             {
                 verifySignatures = (short)Array.IndexOf(ServerCfgArrays.VerifySignaturesStrings, value);
-                RaisePropertyChanged("VerifySignatures");
+                RaisePropertyChanged(nameof(VerifySignatures));
             }
         }
 
@@ -492,7 +560,7 @@ namespace FASTER.Models
             set
             {
                 drawingInMap = value;
-                RaisePropertyChanged("DrawinginMap");
+                RaisePropertyChanged(nameof(DrawinginMap));
             }
         }
 
@@ -502,7 +570,7 @@ namespace FASTER.Models
             set
             {
                 disableVoN = value ? (short)0 : (short)1;
-                RaisePropertyChanged("VonActivated");
+                RaisePropertyChanged(nameof(VonActivated));
             }
         }
 
@@ -512,7 +580,7 @@ namespace FASTER.Models
             set
             {
                 vonCodecQuality = value;
-                RaisePropertyChanged("VonCodecQuality");
+                RaisePropertyChanged(nameof(VonCodecQuality));
             }
         }
 
@@ -522,7 +590,7 @@ namespace FASTER.Models
             set
             {
                 vonCodec = (short)Array.IndexOf(ServerCfgArrays.VonCodecStrings, value);
-                RaisePropertyChanged("VonCodec");
+                RaisePropertyChanged(nameof(VonCodec));
             }
         }
 
@@ -532,7 +600,7 @@ namespace FASTER.Models
             set
             {
                 skipLobby = value;
-                RaisePropertyChanged("SkipLobby");
+                RaisePropertyChanged(nameof(SkipLobby));
             }
         }
 
@@ -542,7 +610,7 @@ namespace FASTER.Models
             set
             {
                 logFile = value;
-                RaisePropertyChanged("LogFile");
+                RaisePropertyChanged(nameof(LogFile));
             }
         }
 
@@ -552,7 +620,7 @@ namespace FASTER.Models
             set
             {
                 battlEye = value ? (short)1 : (short)0;
-                RaisePropertyChanged("BattlEye");
+                RaisePropertyChanged(nameof(BattlEye));
             }
         }
 
@@ -562,7 +630,7 @@ namespace FASTER.Models
             set
             {
                 timeStampFormat = value;
-                RaisePropertyChanged("TimeStampFormat");
+                RaisePropertyChanged(nameof(TimeStampFormat));
             }
         }
 
@@ -574,7 +642,7 @@ namespace FASTER.Models
                 persistent = value ? (short)1 : (short)0;
                 if (!value)
                     AutoInit = false;
-                RaisePropertyChanged("Persistent");
+                RaisePropertyChanged(nameof(Persistent));
             }
         }
 
@@ -584,7 +652,7 @@ namespace FASTER.Models
             set
             {
                 requiredBuildChecked = value;
-                RaisePropertyChanged("RequiredBuildChecked");
+                RaisePropertyChanged(nameof(RequiredBuildChecked));
             }
         }
 
@@ -594,7 +662,7 @@ namespace FASTER.Models
             set
             {
                 requiredBuild = value;
-                RaisePropertyChanged("RequiredBuild");
+                RaisePropertyChanged(nameof(RequiredBuild));
             }
         }
 
@@ -604,7 +672,7 @@ namespace FASTER.Models
             set
             {
                 steamProtocolMaxDataSize = value;
-                RaisePropertyChanged("SteamProtocolMaxDataSize");
+                RaisePropertyChanged(nameof(SteamProtocolMaxDataSize));
             }
         }
         #endregion
@@ -617,7 +685,7 @@ namespace FASTER.Models
             set
             {
                 doubleIdDetected = value;
-                RaisePropertyChanged("DoubleIdDetected");
+                RaisePropertyChanged(nameof(DoubleIdDetected));
             }
         }
 
@@ -627,7 +695,7 @@ namespace FASTER.Models
             set
             {
                 onUserConnected = value;
-                RaisePropertyChanged("OnUserConnected");
+                RaisePropertyChanged(nameof(OnUserConnected));
             }
         }
 
@@ -637,7 +705,7 @@ namespace FASTER.Models
             set
             {
                 onUserDisconnected = value;
-                RaisePropertyChanged("OnUserDisconnected");
+                RaisePropertyChanged(nameof(OnUserDisconnected));
             }
         }
 
@@ -647,7 +715,7 @@ namespace FASTER.Models
             set
             {
                 onHackedData = value;
-                RaisePropertyChanged("OnHackedData");
+                RaisePropertyChanged(nameof(OnHackedData));
             }
         }
 
@@ -657,7 +725,7 @@ namespace FASTER.Models
             set
             {
                 onDifferentData = value;
-                RaisePropertyChanged("OnDifferentData");
+                RaisePropertyChanged(nameof(OnDifferentData));
             }
         }
 
@@ -667,7 +735,7 @@ namespace FASTER.Models
             set
             {
                 onUnsignedData = value;
-                RaisePropertyChanged("OnUnsignedData");
+                RaisePropertyChanged(nameof(OnUnsignedData));
             }
         }
 
@@ -677,7 +745,7 @@ namespace FASTER.Models
             set
             {
                 onUserKicked = value;
-                RaisePropertyChanged("OnUserKicked");
+                RaisePropertyChanged(nameof(OnUserKicked));
             }
         }
         #endregion
@@ -689,7 +757,7 @@ namespace FASTER.Models
             set
             {
                 missionSelectorChecked = value;
-                RaisePropertyChanged("MissionChecked");
+                RaisePropertyChanged(nameof(MissionChecked));
             }
         }
 
@@ -699,7 +767,7 @@ namespace FASTER.Models
             set
             {
                 missionContentOverride = value;
-                RaisePropertyChanged("MissionContentOverride");
+                RaisePropertyChanged(nameof(MissionContentOverride));
             }
         }
 
@@ -709,7 +777,7 @@ namespace FASTER.Models
             set
             {
                 autoInit = value;
-                RaisePropertyChanged("AutoInit");
+                RaisePropertyChanged(nameof(AutoInit));
             }
         }
 
@@ -719,7 +787,7 @@ namespace FASTER.Models
             set
             {
                 difficulty = value;
-                RaisePropertyChanged("Difficulty");
+                RaisePropertyChanged(nameof(Difficulty));
             }
         }
 
@@ -740,7 +808,7 @@ namespace FASTER.Models
                 if (!isEqual)
                 {
                     _missions = value;
-                    RaisePropertyChanged("Missions");
+                    RaisePropertyChanged(nameof(Missions));
                 }
 
                 //Adding the trigger to count checked mods
@@ -756,7 +824,7 @@ namespace FASTER.Models
             set
             {
                 maxMemOverride = value;
-                RaisePropertyChanged("MaxMemOverride");
+                RaisePropertyChanged(nameof(MaxMemOverride));
             }
         }
 
@@ -766,7 +834,7 @@ namespace FASTER.Models
             set
             {
                 cpuCountOverride = value;
-                RaisePropertyChanged("CpuCountOverride");
+                RaisePropertyChanged(nameof(CpuCountOverride));
             }
         }
 
@@ -776,7 +844,7 @@ namespace FASTER.Models
             set
             {
                 maxMem = value;
-                RaisePropertyChanged("MaxMem");
+                RaisePropertyChanged(nameof(MaxMem));
             }
         }
 
@@ -786,7 +854,7 @@ namespace FASTER.Models
             set
             {
                 cpuCount = value;
-                RaisePropertyChanged("CpuCount");
+                RaisePropertyChanged(nameof(CpuCount));
             }
         }
 
@@ -796,7 +864,7 @@ namespace FASTER.Models
             set
             {
                 commandLineParams = value;
-                RaisePropertyChanged("CommandLineParameters");
+                RaisePropertyChanged(nameof(CommandLineParameters));
             }
         }
 
@@ -808,7 +876,7 @@ namespace FASTER.Models
             set
             {
                 serverCfgContent = value;
-                RaisePropertyChanged("ServerCfgContent");
+                RaisePropertyChanged(nameof(ServerCfgContent));
             }
         }
 
@@ -820,8 +888,8 @@ namespace FASTER.Models
 
         private void Item_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            RaisePropertyChanged("MissionChecked");
-            RaisePropertyChanged("MissionContentOverride");
+            RaisePropertyChanged(nameof(MissionChecked));
+            RaisePropertyChanged(nameof(MissionContentOverride));
         }
 
         public string ProcessFile()
@@ -893,10 +961,9 @@ namespace FASTER.Models
                           + $"timeStampFormat = \"{timeStampFormat}\";\t\t// Set the timestamp format used on each report line in server-side RPT file. Possible values are \"none\" (default),\"short\",\"full\".\r\n"
                           + $"BattlEye = {battlEye};\t\t\t\t// Server to use BattlEye system\r\n"
                           + $"queueSizeLogG = {queueSizeLogG};\t\t\t// If a specific players message queue is larger than 1MB and #monitor is running, dump his messages to a logfile for analysis \r\n"
-                          + $"LogObjectNotFound = {logObjectNotFound};\t\t// When false to skip logging 'Server: Object not found messages'.\r\n"
-                          + $"SkipDescriptionParsing = {skipDescriptionParsing};\t\t// When true to skip parsing of description.ext/mission.sqm. Will show pbo filename instead of configured missionName. OverviewText and such won't work, but loading the mission list is a lot faster when there are many missions \r\n"
+                          + $"class AdvancedOptions\r\n{{\r\n\tLogObjectNotFound = {logObjectNotFound};\t\t// When false to skip logging 'Server: Object not found messages'.\r\n\tSkipDescriptionParsing = {skipDescriptionParsing};\t\t// When true to skip parsing of description.ext/mission.sqm. Will show pbo filename instead of configured missionName. OverviewText and such won't work, but loading the mission list is a lot faster when there are many missions.\r\n}};\r\n"
                           + $"ignoreMissionLoadErrors = {ignoreMissionLoadErrors};\t\t// When set to true, the mission will load no matter the amount of loading errors. If set to false, the server will abort mission's loading and return to mission selection.\r\n"
-                          + $"forcedDifficulty = {forcedDifficulty};\t\t\t// Forced difficulty (Recruit, Regular, Veteran, Custom)\r\n"
+                          + $"forcedDifficulty = \"{forcedDifficulty}\";\t\t\t// Forced difficulty (Recruit, Regular, Veteran, Custom)\r\n"
                           + "\r\n"
                           + "// TIMEOUTS\r\n"
                           + $"disconnectTimeout = {disconnectTimeout};\t\t\t// Time to wait before disconnecting a user which temporarly lost connection. Range is 5 to 90 seconds.\r\n"
@@ -925,6 +992,7 @@ namespace FASTER.Models
                           + "// MISSIONS CYCLE (see below)\r\n"
                           + $"randomMissionOrder = {randomMissionOrder};\t\t// Randomly iterate through Missions list\r\n"
                           + $"autoSelectMission = {autoSelectMission};\t\t\t// Server auto selects next mission in cycle\r\n"
+                          + (!string.IsNullOrWhiteSpace(MissionHTTPDownloadBaseURL) ? $"missionHTTPDownloadBaseURL = \"{MissionHTTPDownloadBaseURL}\";\r\n" : "")
                           + "\r\n"
                           + $"{MissionContentOverride}\t\t\t\t\t// An empty Missions class means there will be no mission rotation\r\n"
                           + "\r\n"
@@ -933,7 +1001,8 @@ namespace FASTER.Models
                           + "\r\n"
                           + "// HEADLESS CLIENT\r\n"
                           + $"{(headlessClientEnabled && !headlessClients.Exists(string.IsNullOrWhiteSpace) ? $"headlessClients[] =  { "{\n\t\"" + string.Join("\",\n\t \"", headlessClients) + "\"\n}" };\r\n" : "")}"
-                          + $"{(headlessClientEnabled && !localClient.Exists(string.IsNullOrWhiteSpace)? $"localClient[] =  { "{\n\t\"" + string.Join("\",\n\t \"", localClient) + "\"\n}" };" : "")}";
+                          + $"{(headlessClientEnabled && !localClient.Exists(string.IsNullOrWhiteSpace)? $"localClient[] =  { "{\n\t\"" + string.Join("\",\n\t \"", localClient) + "\"\n}" };" : "")}"
+                          + (AntiFloodEnabled ? $"class AntiFlood\r\n{{\r\n\tcycleTime = {AntiFloodCycleTime};\r\n\tcycleLimit = {AntiFloodCycleLimit};\r\n\tcycleHardLimit = {AntiFloodCycleHardLimit};\r\n\tenableKick = {_antiFloodEnableKick};\r\n}};\r\n" : "");
             return output;
         }
 
@@ -960,7 +1029,7 @@ namespace FASTER.Models
             set
             {
                 missionChecked = value;
-                RaisePropertyChanged("MissionChecked");
+                RaisePropertyChanged(nameof(MissionChecked));
             }
         }
 
@@ -970,7 +1039,7 @@ namespace FASTER.Models
             set
             {
                 name = value;
-                RaisePropertyChanged("Name");
+                RaisePropertyChanged(nameof(Name));
             }
         }
 
@@ -980,7 +1049,7 @@ namespace FASTER.Models
             set
             {
                 path = value;
-                RaisePropertyChanged("Path");
+                RaisePropertyChanged(nameof(Path));
             }
         }
 

--- a/FASTER/Models/ServerProfile.cs
+++ b/FASTER/Models/ServerProfile.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -64,6 +64,13 @@ namespace FASTER.Models
         private bool _efDlcChecked;
         private bool _enableHT = true;
         private bool _enableRanking;
+        private bool _hugePages = false;
+        private string _bePath = "";
+        private string _keysFolder = "";
+        private int _exThreads = 0;
+        private bool _loadMissionToMemory = false;
+        private int _limitFPS = 0;
+        private bool _enableSteamLogs = false;
 
         private List<ProfileMod> _profileMods = new List<ProfileMod>();
         private string _profileModsFilter = "";
@@ -94,7 +101,14 @@ namespace FASTER.Models
                 _name = value;
                 if (MainWindow.HasLoaded())
                 {
-                    var menuItem = MainWindow.Instance.IServerProfilesMenu.Items.Cast<ToggleButton>().FirstOrDefault(p => p.Name == _id);
+                    ToggleButton menuItem = null;
+                    foreach (var item in MainWindow.Instance.IServerProfilesMenu.Items)
+                    {
+                        ToggleButton tb = item is System.Windows.Controls.DockPanel dp
+                            ? dp.Children.OfType<ToggleButton>().FirstOrDefault()
+                            : item as ToggleButton;
+                        if (tb?.Name == _id) { menuItem = tb; break; }
+                    }
                     if (menuItem != null)
                     { menuItem.Content = _name; }
                 }
@@ -242,6 +256,76 @@ namespace FASTER.Models
             {
                 _enableRanking = value;
                 RaisePropertyChanged("RankingChecked");
+            }
+        }
+
+        public bool HugePages
+        {
+            get => _hugePages;
+            set
+            {
+                _hugePages = value;
+                RaisePropertyChanged(nameof(HugePages));
+            }
+        }
+
+        public string BePath
+        {
+            get => _bePath;
+            set
+            {
+                _bePath = value;
+                RaisePropertyChanged(nameof(BePath));
+            }
+        }
+
+        public string KeysFolder
+        {
+            get => _keysFolder;
+            set
+            {
+                _keysFolder = value;
+                RaisePropertyChanged(nameof(KeysFolder));
+            }
+        }
+
+        public int ExThreads
+        {
+            get => _exThreads;
+            set
+            {
+                _exThreads = value;
+                RaisePropertyChanged(nameof(ExThreads));
+            }
+        }
+
+        public bool LoadMissionToMemory
+        {
+            get => _loadMissionToMemory;
+            set
+            {
+                _loadMissionToMemory = value;
+                RaisePropertyChanged(nameof(LoadMissionToMemory));
+            }
+        }
+
+        public int LimitFPS
+        {
+            get => _limitFPS;
+            set
+            {
+                _limitFPS = value;
+                RaisePropertyChanged(nameof(LimitFPS));
+            }
+        }
+
+        public bool EnableSteamLogs
+        {
+            get => _enableSteamLogs;
+            set
+            {
+                _enableSteamLogs = value;
+                RaisePropertyChanged(nameof(EnableSteamLogs));
             }
         }
 
@@ -547,6 +631,13 @@ namespace FASTER.Models
                 $"{(ServerCfg.AutoInit ? " -autoInit" : "")}",
                 $"{(ServerCfg.MaxMemOverride ? $" -maxMem={ServerCfg.MaxMem}" : "")}",
                 $"{(ServerCfg.CpuCountOverride ? $" -cpuCount={ServerCfg.CpuCount}" : "")}",
+                $"{(HugePages ? " -hugePages" : "")}",
+                $"{(!string.IsNullOrWhiteSpace(BePath) ? $" \"-bepath={BePath}\"" : "")}",
+                $"{(!string.IsNullOrWhiteSpace(KeysFolder) ? $" \"-keysFolder={KeysFolder}\"" : "")}",
+                $"{(ExThreads > 0 ? $" -exThreads={ExThreads}" : "")}",
+                $"{(LoadMissionToMemory ? " -loadMissionToMemory" : "")}",
+                $"{(LimitFPS > 0 ? $" -limitFPS={LimitFPS}" : "")}",
+                $"{(EnableSteamLogs ? " -enableSteamLogs" : "")}",
                 $"{(!string.IsNullOrWhiteSpace(ServerCfg.CommandLineParameters) ? $" {ServerCfg.CommandLineParameters}" : "")}"
             };
 

--- a/FASTER/Models/SteamWebApi.cs
+++ b/FASTER/Models/SteamWebApi.cs
@@ -84,9 +84,13 @@ namespace FASTER.Models
             // Display the status.
             Console.WriteLine((response)?.StatusCode);
 
-            return response == null
-                       ? null
-                       : JObject.Parse(response.Content.ReadAsStringAsync().Result);
+            if (response == null)
+                return null;
+
+            if (!response.IsSuccessStatusCode)
+                throw new Exception($"Steam API returned HTTP {(int)response.StatusCode} {response.StatusCode}. Please check your Steam API Key in Settings.");
+
+            return JObject.Parse(response.Content.ReadAsStringAsync().Result);
 
             // Return the response
         }

--- a/FASTER/Properties/Settings.Designer.cs
+++ b/FASTER/Properties/Settings.Designer.cs
@@ -201,6 +201,18 @@ namespace FASTER.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool enableDebugLog {
+            get {
+                return ((bool)(this["enableDebugLog"]));
+            }
+            set {
+                this["enableDebugLog"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool checkForModUpdates {
             get {

--- a/FASTER/Properties/Settings.settings
+++ b/FASTER/Properties/Settings.settings
@@ -95,5 +95,8 @@
     <Setting Name="usingEFDlc" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="enableDebugLog" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/FASTER/ViewModel/DeploymentViewModel.cs
+++ b/FASTER/ViewModel/DeploymentViewModel.cs
@@ -108,8 +108,11 @@ namespace FASTER.ViewModel
                 {"Name", Settings.Default.steamUserName}
             });
 
+            Logger.Log($"DeployAll: installPath={Deployment.InstallPath}, mods={Deployment.DeployMods.Count}");
+
             if (!Directory.Exists(Deployment.InstallPath))
             {
+                Logger.Log("DeployAll: install path not found, aborting.");
                 DisplayMessage("Arma Install Path is empty.\nMake sure you have entered a valid path before deploying mods.");
                 return;
             }
@@ -118,10 +121,12 @@ namespace FASTER.ViewModel
             {
                 var linkPath = Path.Combine(Deployment.InstallPath, $"@{Functions.SafeName(mod.Name)}");
                 mod.Marked = true;
+                Logger.Log($"  Linking {mod.Name}: {mod.Path} -> {linkPath}");
                 LinkMod(mod, linkPath);
             }
             Settings.Default.Deployments = Deployment;
             Settings.Default.Save();
+            Logger.Log("DeployAll: done.");
         }
 
         /// <summary>
@@ -212,22 +217,36 @@ namespace FASTER.ViewModel
         /// <param name="linkPath"></param>
         private void LinkMod(DeploymentMod mod, string linkPath)
         {
+            Logger.Log($"LinkMod: {mod.Name} ({mod.WorkshopId}) -> {linkPath}");
             try
             {
                 if(Directory.Exists(linkPath))
                 {
                     if (new DirectoryInfo(linkPath).Attributes.HasFlag(FileAttributes.ReparsePoint))
+                    {
+                        Logger.Log($"  Removing existing symlink: {linkPath}");
                         Directory.Delete(linkPath);
+                    }
                     else
+                    {
+                        Logger.Log($"  Removing existing real dir: {linkPath}");
                         Directory.Delete(linkPath, true);
+                    }
                 }
 
                 Directory.CreateSymbolicLink(linkPath ?? throw new ArgumentNullException(nameof(linkPath)), mod.Path);
+                Logger.Log($"  Symlink created OK.");
             }
             catch (UnauthorizedAccessException)
-            { DisplayMessage("Could not create symlink: Access denied.\n\nTo deploy mods, enable Windows Developer Mode in Settings → Update & Security → For Developers, or run FASTER as Administrator."); }
+            {
+                Logger.Log($"  ERROR: UnauthorizedAccessException creating symlink.");
+                DisplayMessage("Could not create symlink: Access denied.\n\nTo deploy mods, enable Windows Developer Mode in Settings → Update & Security → For Developers, or run FASTER as Administrator.");
+            }
             catch (Exception ex)
-            { DisplayMessage("An exception occurred: \n\n" + ex.Message); }
+            {
+                Logger.Log($"  ERROR: {ex.Message}");
+                DisplayMessage("An exception occurred: \n\n" + ex.Message);
+            }
         }
 
         /// <summary>

--- a/FASTER/ViewModel/DeploymentViewModel.cs
+++ b/FASTER/ViewModel/DeploymentViewModel.cs
@@ -108,12 +108,20 @@ namespace FASTER.ViewModel
                 {"Name", Settings.Default.steamUserName}
             });
 
+            if (!Directory.Exists(Deployment.InstallPath))
+            {
+                DisplayMessage("Arma Install Path is empty.\nMake sure you have entered a valid path before deploying mods.");
+                return;
+            }
+
             foreach (var mod in Deployment.DeployMods)
             {
                 var linkPath = Path.Combine(Deployment.InstallPath, $"@{Functions.SafeName(mod.Name)}");
                 mod.Marked = true;
                 LinkMod(mod, linkPath);
             }
+            Settings.Default.Deployments = Deployment;
+            Settings.Default.Save();
         }
 
         /// <summary>
@@ -207,10 +215,17 @@ namespace FASTER.ViewModel
             try
             {
                 if(Directory.Exists(linkPath))
-                    Directory.Delete(linkPath, true);
+                {
+                    if (new DirectoryInfo(linkPath).Attributes.HasFlag(FileAttributes.ReparsePoint))
+                        Directory.Delete(linkPath);
+                    else
+                        Directory.Delete(linkPath, true);
+                }
 
                 Directory.CreateSymbolicLink(linkPath ?? throw new ArgumentNullException(nameof(linkPath)), mod.Path);
             }
+            catch (UnauthorizedAccessException)
+            { DisplayMessage("Could not create symlink: Access denied.\n\nTo deploy mods, enable Windows Developer Mode in Settings → Update & Security → For Developers, or run FASTER as Administrator."); }
             catch (Exception ex)
             { DisplayMessage("An exception occurred: \n\n" + ex.Message); }
         }
@@ -224,7 +239,12 @@ namespace FASTER.ViewModel
             try
             {
                 if (Directory.Exists(linkPath))
-                    Directory.Delete(linkPath, true);
+                {
+                    if (new DirectoryInfo(linkPath).Attributes.HasFlag(FileAttributes.ReparsePoint))
+                        Directory.Delete(linkPath);
+                    else
+                        Directory.Delete(linkPath, true);
+                }
             }
             catch (Exception ex)
             { DisplayMessage("An exception occurred: \n\n" + ex.Message); }

--- a/FASTER/ViewModel/ModsViewModel.cs
+++ b/FASTER/ViewModel/ModsViewModel.cs
@@ -230,10 +230,13 @@ namespace FASTER.ViewModel
 
             Process.Start(startInfo);
         }
-        public void CheckForUpdates()
+        public async Task CheckForUpdates()
         {
             foreach (ArmaMod mod in ModsCollection.ArmaMods)
-            { Task.Run(() => mod.UpdateInfos()); }
+            {
+                await Task.Run(() => mod.UpdateInfos());
+                await Task.Delay(300);
+            }
         }
 
         public async Task UpdateSelectedMods()
@@ -253,8 +256,75 @@ namespace FASTER.ViewModel
 
             MainWindow.Instance.NavigateToConsole();
             var ans = await MainWindow.Instance.SteamUpdaterViewModel.RunModsUpdater(ModsCollection.ArmaMods);
-            if(ans == UpdateState.LoginFailed) 
+            if(ans == UpdateState.LoginFailed)
                 DisplayMessage("Steam Login Failed");
+        }
+
+        public void PurgeAndReinstallMod(ArmaMod mod)
+        {
+            if (mod == null) return;
+
+            try
+            {
+                if (Directory.Exists(mod.Path))
+                    Directory.Delete(mod.Path, true);
+            }
+            catch
+            { DisplayMessage($"Could not delete folder for mod {mod.WorkshopId}"); }
+
+            mod.Status           = ArmaModStatus.UpdateRequired;
+            mod.LocalLastUpdated = 0;
+            mod.Size             = 0;
+            Properties.Settings.Default.Save();
+        }
+
+        public void PurgeAndReinstallSelectedMods()
+        {
+            var selectedMods = new List<ArmaMod>(ModsCollection.ArmaMods.Where(m => m.IsSelected && !m.IsLocal));
+            foreach (var mod in selectedMods)
+                PurgeAndReinstallMod(mod);
+        }
+
+        public async Task PurgeAndReinstallAll()
+        {
+            var answer = await DialogCoordinator.ShowInputAsync(this, "Are you sure you want to purge all mods?", "Write \"yes\" and press OK to delete all mod folders and mark them for re-download.");
+
+            if (string.IsNullOrEmpty(answer) || !answer.Equals("yes"))
+                return;
+
+            Analytics.TrackEvent("Mods - Clicked PurgeAndReinstallAll", new Dictionary<string, string>
+            {
+                {"Name", Properties.Settings.Default.steamUserName}
+            });
+
+            foreach (var mod in ModsCollection.ArmaMods.Where(m => !m.IsLocal).ToList())
+                PurgeAndReinstallMod(mod);
+        }
+
+        public async Task PurgeUnusedMods()
+        {
+            var usedIds = Properties.Settings.Default.Profiles
+                .SelectMany(p => p.ProfileMods ?? Enumerable.Empty<ProfileMod>())
+                .Select(m => m.Id)
+                .ToHashSet();
+
+            var unusedMods = ModsCollection.ArmaMods
+                .Where(m => !m.IsLocal && !usedIds.Contains(m.WorkshopId))
+                .ToList();
+
+            if (unusedMods.Count == 0)
+            {
+                DisplayMessage("No unused mods found.");
+                return;
+            }
+
+            var result = await DialogCoordinator.ShowInputAsync(this,
+                "Purge Unused Mods",
+                $"Found {unusedMods.Count} unused mod(s). Type \"yes\" to confirm deletion.");
+            if (result?.ToLower() != "yes") return;
+
+            foreach (var mod in unusedMods)
+                DeleteMod(mod);
         }
     }
 }

--- a/FASTER/ViewModel/ModsViewModel.cs
+++ b/FASTER/ViewModel/ModsViewModel.cs
@@ -232,11 +232,14 @@ namespace FASTER.ViewModel
         }
         public async Task CheckForUpdates()
         {
+            Logger.Log("CheckForUpdates started.");
             foreach (ArmaMod mod in ModsCollection.ArmaMods)
             {
+                Logger.Log($"  Checking mod {mod.WorkshopId} ({mod.Name})...");
                 await Task.Run(() => mod.UpdateInfos());
                 await Task.Delay(300);
             }
+            Logger.Log("CheckForUpdates finished.");
         }
 
         public async Task UpdateSelectedMods()
@@ -264,13 +267,22 @@ namespace FASTER.ViewModel
         {
             if (mod == null) return;
 
+            Logger.Log($"PurgeAndReinstallMod: {mod.WorkshopId} ({mod.Name}) path={mod.Path}");
             try
             {
                 if (Directory.Exists(mod.Path))
+                {
                     Directory.Delete(mod.Path, true);
+                    Logger.Log($"  Deleted folder: {mod.Path}");
+                }
+                else
+                    Logger.Log($"  Folder not found, skipping delete: {mod.Path}");
             }
-            catch
-            { DisplayMessage($"Could not delete folder for mod {mod.WorkshopId}"); }
+            catch (Exception ex)
+            {
+                Logger.Log($"  ERROR deleting folder: {ex.Message}");
+                DisplayMessage($"Could not delete folder for mod {mod.WorkshopId}");
+            }
 
             mod.Status           = ArmaModStatus.UpdateRequired;
             mod.LocalLastUpdated = 0;
@@ -287,7 +299,7 @@ namespace FASTER.ViewModel
 
         public async Task PurgeAndReinstallAll()
         {
-            var answer = await DialogCoordinator.ShowInputAsync(this, "Are you sure you want to purge all mods?", "Write \"yes\" and press OK to delete all mod folders and mark them for re-download.");
+            var answer = await DialogCoordinator.ShowInputAsync(this, "Are you sure you want to purge all mods?", "Write \"yes\" and press OK to delete all folders in the Mod Staging Directory and re-download everything.");
 
             if (string.IsNullOrEmpty(answer) || !answer.Equals("yes"))
                 return;
@@ -297,8 +309,41 @@ namespace FASTER.ViewModel
                 {"Name", Properties.Settings.Default.steamUserName}
             });
 
+            var stagingDir = Properties.Settings.Default.modStagingDirectory;
+            Logger.Log($"PurgeAndReinstallAll: staging dir={stagingDir}");
+            if (Directory.Exists(stagingDir))
+            {
+                foreach (var dir in Directory.GetDirectories(stagingDir))
+                {
+                    try
+                    {
+                        Directory.Delete(dir, true);
+                        Logger.Log($"  Deleted: {dir}");
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"  ERROR deleting {dir}: {ex.Message}");
+                        DisplayMessage($"Could not delete folder: {dir}");
+                    }
+                }
+            }
+            else
+                Logger.Log("  Staging dir does not exist, nothing deleted.");
+
             foreach (var mod in ModsCollection.ArmaMods.Where(m => !m.IsLocal).ToList())
-                PurgeAndReinstallMod(mod);
+            {
+                mod.Status           = ArmaModStatus.UpdateRequired;
+                mod.LocalLastUpdated = 0;
+                mod.Size             = 0;
+                Logger.Log($"  Reset mod {mod.WorkshopId} ({mod.Name})");
+            }
+            Properties.Settings.Default.Save();
+
+            Logger.Log("PurgeAndReinstallAll: launching UpdateAll...");
+            MainWindow.Instance.NavigateToConsole();
+            var ans = await MainWindow.Instance.SteamUpdaterViewModel.RunModsUpdater(ModsCollection.ArmaMods);
+            if (ans == UpdateState.LoginFailed)
+                DisplayMessage("Steam Login Failed");
         }
 
         public async Task PurgeUnusedMods()

--- a/FASTER/ViewModel/ProfileViewModel.cs
+++ b/FASTER/ViewModel/ProfileViewModel.cs
@@ -34,6 +34,7 @@ namespace FASTER.ViewModel
         public ObservableCollection<string> MissionDifficulties { get; } = new ObservableCollection<string> { "Recruit", "Regular", "Veteran", "Custom" };
         public ObservableCollection<string> PerfPresets         { get; } = new ObservableCollection<string>(BasicCfgArrays.PerfPresets);
         public ObservableCollection<double> TerrainGrids        { get; } = new ObservableCollection<double>(BasicCfgArrays.TerrainGrids);
+        public ObservableCollection<string> Languages           { get; } = new ObservableCollection<string>(BasicCfgArrays.Languages);
 
         internal void DisplayMessage(string msg)
         {
@@ -320,6 +321,54 @@ namespace FASTER.ViewModel
             {
                 DisplayMessage($"Some mods in the preset were not found: \n{string.Join("\n\t", notFound)}");
             }
+        }
+
+        internal void SelectBePath()
+        {
+            var dialog = new CommonOpenFileDialog
+            {
+                Title                     = "Select the BattlEye directory",
+                IsFolderPicker            = true,
+                AddToMostRecentlyUsedList = false,
+                AllowNonFileSystemItems   = false,
+                EnsureFileExists          = false,
+                EnsurePathExists          = true,
+                EnsureReadOnly            = false,
+                EnsureValidNames          = true,
+                Multiselect               = false,
+                ShowPlacesList            = true
+            };
+
+            if (dialog.ShowDialog() != CommonFileDialogResult.Ok) return;
+
+            if (dialog.FileName != null)
+            { Profile.BePath = dialog.FileName; }
+            else
+            { MessageBox.Show("Please enter a valid BattlEye directory"); }
+        }
+
+        internal void SelectKeysFolder()
+        {
+            var dialog = new CommonOpenFileDialog
+            {
+                Title                     = "Select the keys directory",
+                IsFolderPicker            = true,
+                AddToMostRecentlyUsedList = false,
+                AllowNonFileSystemItems   = false,
+                EnsureFileExists          = false,
+                EnsurePathExists          = true,
+                EnsureReadOnly            = false,
+                EnsureValidNames          = true,
+                Multiselect               = false,
+                ShowPlacesList            = true
+            };
+
+            if (dialog.ShowDialog() != CommonFileDialogResult.Ok) return;
+
+            if (dialog.FileName != null)
+            { Profile.KeysFolder = dialog.FileName; }
+            else
+            { MessageBox.Show("Please enter a valid keys directory"); }
         }
 
         internal void SelectServerFile()

--- a/FASTER/ViewModel/SteamUpdaterViewModel.cs
+++ b/FASTER/ViewModel/SteamUpdaterViewModel.cs
@@ -761,7 +761,7 @@ namespace FASTER.ViewModel
             downloadHandler.FileDownloaded        += (_, args) =>
             {
                 downloadedSize    += args.TotalSize;
-                Logger.Log($"  File downloaded: {args.ManifestFile?.FileName}, progress {downloadHandler.TotalProgress * 100:00.00}% ({Functions.ParseFileSize(downloadedSize)}/{Functions.ParseFileSize(downloadHandler.TotalFileSize)})");
+                Logger.Log($"  File downloaded: progress {downloadHandler.TotalProgress * 100:00.00}% ({Functions.ParseFileSize(downloadedSize)}/{Functions.ParseFileSize(downloadHandler.TotalFileSize)})");
                 Parameters.Output += $"\n    Progress {downloadHandler.TotalProgress * 100:00.00}% ({Functions.ParseFileSize(downloadedSize)} / {Functions.ParseFileSize(downloadHandler.TotalFileSize)})";
             };
             downloadHandler.DownloadComplete      += (_, _) =>

--- a/FASTER/ViewModel/SteamUpdaterViewModel.cs
+++ b/FASTER/ViewModel/SteamUpdaterViewModel.cs
@@ -415,13 +415,22 @@ namespace FASTER.ViewModel
 
         public async Task<int> RunModsUpdater(ObservableCollection<ArmaMod> mods)
         {
+            Logger.Log($"RunModsUpdater: starting, {mods.Count} mods total");
 
             tokenSource = new CancellationTokenSource();
-            if(!await SteamLogin())
-            { 
+
+            Logger.Log("RunModsUpdater: calling SteamLogin...");
+            bool loginOk = false;
+            try { loginOk = await SteamLogin(); }
+            catch (Exception ex) { Logger.Log($"RunModsUpdater: SteamLogin threw exception: {ex}"); }
+
+            if (!loginOk)
+            {
+                Logger.Log("RunModsUpdater: SteamLogin failed, aborting.");
                 IsLoggingIn = false;
                 return UpdateState.LoginFailed;
             }
+            Logger.Log("RunModsUpdater: SteamLogin OK");
 
             Parameters.Output += "\nAdding mods to download list...";
 
@@ -429,79 +438,104 @@ namespace FASTER.ViewModel
             var  ml = mods.Where(m => !m.IsLocal).ToList();
             uint finished = 0;
             IsDlOverride = true;
+            Logger.Log($"RunModsUpdater: {ml.Count} non-local mods to update");
 
             foreach (ArmaMod mod in ml)
             {
+                Logger.Log($"RunModsUpdater: waiting semaphore for mod {mod.WorkshopId} ({mod.Name})");
                 await maxThread.WaitAsync();
 
                 _ = Task.Factory.StartNew(async () =>
                 {
-                    if (!Directory.Exists(mod.Path))
-                        Directory.CreateDirectory(mod.Path);
-
-                    if (tokenSource.Token.IsCancellationRequested)
-                    {
-                        return;
-                    }
-                    Parameters.Output += $"\n   Starting {mod.WorkshopId}";
-
-                    Stopwatch sw = Stopwatch.StartNew();
+                    Logger.Log($"  Task started: {mod.WorkshopId} ({mod.Name}), path={mod.Path}");
                     try
                     {
-                        ManifestId manifestId = default;
-
-                        if(mod.LocalLastUpdated > mod.SteamLastUpdated && mod.Size > 0)
+                        if (!Directory.Exists(mod.Path))
                         {
-                            mod.Status = ArmaModStatus.UpToDate;
-                            Parameters.Output += $"\n   Mod{mod.WorkshopId} already up to date. Ignoring...";
+                            Logger.Log($"  Creating dir: {mod.Path}");
+                            Directory.CreateDirectory(mod.Path);
+                        }
+
+                        if (tokenSource.Token.IsCancellationRequested)
+                        {
+                            Logger.Log($"  Cancellation requested before {mod.WorkshopId}, skipping.");
                             return;
                         }
+                        Parameters.Output += $"\n   Starting {mod.WorkshopId}";
 
-                        if (!SteamClient.Credentials.IsAnonymous) //IS SYNC NEABLED
+                        Stopwatch sw = Stopwatch.StartNew();
+                        try
                         {
-                            Parameters.Output += $"\n   Getting manifest for {mod.WorkshopId}";
-                            manifestId = (await SteamContentClient.GetPublishedFileDetailsAsync(mod.WorkshopId)).hcontent_file;
-                            Manifest manifest = await SteamContentClient.GetManifestAsync(107410, 107410, manifestId);
-                            Parameters.Output += $"\n   Manifest retrieved {mod.WorkshopId}";
-                            SyncDeleteRemovedFiles(mod.Path, manifest);
+                            ManifestId manifestId = default;
+
+                            if(mod.LocalLastUpdated > mod.SteamLastUpdated && mod.Size > 0)
+                            {
+                                mod.Status = ArmaModStatus.UpToDate;
+                                Parameters.Output += $"\n   Mod{mod.WorkshopId} already up to date. Ignoring...";
+                                Logger.Log($"  {mod.WorkshopId} already up to date, skipping.");
+                                return;
+                            }
+
+                            if (!SteamClient.Credentials.IsAnonymous)
+                            {
+                                Logger.Log($"  Getting manifest for {mod.WorkshopId}");
+                                Parameters.Output += $"\n   Getting manifest for {mod.WorkshopId}";
+                                manifestId = (await SteamContentClient.GetPublishedFileDetailsAsync(mod.WorkshopId)).hcontent_file;
+                                Manifest manifest = await SteamContentClient.GetManifestAsync(107410, 107410, manifestId);
+                                Parameters.Output += $"\n   Manifest retrieved {mod.WorkshopId}";
+                                Logger.Log($"  Manifest retrieved for {mod.WorkshopId}, syncing deleted files...");
+                                SyncDeleteRemovedFiles(mod.Path, manifest);
+                            }
+
+                            Logger.Log($"  Requesting download handler for {mod.WorkshopId}");
+                            Parameters.Output += $"\n    Attempting to start download of item {mod.WorkshopId}... ";
+
+                            var downloadHandler = await SteamContentClient.GetPublishedFileDataAsync(mod.WorkshopId, manifestId, tokenSource.Token);
+                            Logger.Log($"  Download handler obtained for {mod.WorkshopId}, starting download...");
+                            await DownloadForMultiple(downloadHandler, mod.Path);
+                            Logger.Log($"  Download complete for {mod.WorkshopId}");
+
+                            mod.Status = ArmaModStatus.UpToDate;
+                            var nx = DateTime.UnixEpoch;
+                            var ts = DateTime.UtcNow - nx;
+                            mod.LocalLastUpdated = (ulong)ts.TotalSeconds;
                         }
-
-                        Parameters.Output += $"\n    Attempting to start download of item {mod.WorkshopId}... ";
-
-                        var downloadHandler = await SteamContentClient.GetPublishedFileDataAsync(mod.WorkshopId, manifestId, tokenSource.Token);
-                        await DownloadForMultiple(downloadHandler, mod.Path);
-
-                        mod.Status = ArmaModStatus.UpToDate;
-                        var nx = DateTime.UnixEpoch;
-                        var ts = DateTime.UtcNow - nx;
-                        mod.LocalLastUpdated = (ulong)ts.TotalSeconds;
-                    }
-                    catch (TaskCanceledException)
-                    {
+                        catch (TaskCanceledException)
+                        {
+                            Logger.Log($"  {mod.WorkshopId} task cancelled.");
+                            sw.Stop();
+                            mod.Status = ArmaModStatus.NotComplete;
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Log($"  ERROR downloading {mod.WorkshopId}: {ex.GetType().Name}: {ex.Message}{(ex.InnerException != null ? $" | Inner: {ex.InnerException.Message}" : "")}\n  StackTrace: {ex.StackTrace}");
+                            sw.Stop();
+                            mod.Status = ArmaModStatus.NotComplete;
+                            Parameters.Output += $"\nError: {ex.Message}{(ex.InnerException != null ? $" Inner Exception: {ex.InnerException.Message}" : "")}";
+                        }
                         sw.Stop();
-                        mod.Status = ArmaModStatus.NotComplete;
+
+                        mod.CheckModSize();
+                        Parameters.Output += $"\n    Download {mod.WorkshopId} completed, it took {sw.Elapsed.Minutes + sw.Elapsed.Hours*60}m {sw.Elapsed.Seconds}s {sw.Elapsed.Milliseconds}ms";
                     }
                     catch (Exception ex)
                     {
-                        sw.Stop();
-                        mod.Status = ArmaModStatus.NotComplete;
-                        Parameters.Output += $"\nError: {ex.Message}{(ex.InnerException != null ? $" Inner Exception: {ex.InnerException.Message}" : "")}";
+                        Logger.Log($"  UNHANDLED ERROR in task for {mod.WorkshopId}: {ex.GetType().Name}: {ex.Message}\n  StackTrace: {ex.StackTrace}");
                     }
-                    sw.Stop();
 
-                    mod.CheckModSize();
-
-                    Parameters.Output += $"\n    Download {mod.WorkshopId} completed, it took {sw.Elapsed.Minutes + sw.Elapsed.Hours*60}m {sw.Elapsed.Seconds}s {sw.Elapsed.Milliseconds}ms";
-
-                }, TaskCreationOptions.LongRunning).Unwrap().ContinueWith((_) =>
+                }, TaskCreationOptions.LongRunning).Unwrap().ContinueWith((t) =>
                 {
+                    if (t.IsFaulted)
+                        Logger.Log($"  ContinueWith: task for {mod.WorkshopId} faulted: {t.Exception}");
                     finished += 1;
                     Parameters.Output += $"\n   Thread {mod.WorkshopId} complete  ({finished} / {ml.Count})";
                     Parameters.Progress = finished * ml.Count / 100.00;
+                    Logger.Log($"  ContinueWith: mod {mod.WorkshopId} done ({finished}/{ml.Count}), releasing semaphore.");
                     maxThread.Release();
                 });
             }
 
+            Logger.Log("RunModsUpdater: all tasks queued, waiting for last semaphore...");
             Parameters.Output += "\nAlmost there...";
             try
             {
@@ -512,12 +546,14 @@ namespace FASTER.ViewModel
                 IsDlOverride = false;
             }
 
+            Logger.Log("RunModsUpdater: all done.");
             Parameters.Output += "\nMods updated !";
             return UpdateState.Success;
         }
 
         internal async Task<bool> SteamLogin()
         {
+            Logger.Log("SteamLogin: start");
             if (tokenSource.IsCancellationRequested)
                 tokenSource = new CancellationTokenSource();
             IsLoggingIn = true;
@@ -542,13 +578,15 @@ namespace FASTER.ViewModel
                 try
                 { await SteamClient.ConnectAsync(tokenSource.Token); }
                 catch (SteamClientAlreadyRunningException)
-                { 
-                    Parameters.Output += $"\nClient already logged in."; 
+                {
+                    Logger.Log("SteamLogin: SteamClientAlreadyRunningException - client already running");
+                    Parameters.Output += $"\nClient already logged in.";
                     IsLoggingIn = false;
                     return false;
                 }
                 catch (Exception ex)
                 {
+                    Logger.Log($"SteamLogin: ConnectAsync failed: {ex.GetType().Name}: {ex.Message}\nStackTrace: {ex.StackTrace}");
                     Parameters.Output += $"\nFailed! Error: {ex.Message}";
                     var savedUsername = SteamClient?.Credentials.Username;
                     SteamClient.Shutdown();
@@ -566,8 +604,10 @@ namespace FASTER.ViewModel
                 }
             }
 
+            Logger.Log($"SteamLogin: creating SteamContentClient with {Properties.Settings.Default.CliWorkers} workers");
             SteamContentClient = new SteamContentClient(SteamClient, Properties.Settings.Default.CliWorkers);
             Parameters.Output += "\nConnected !";
+            Logger.Log("SteamLogin: connected OK");
             IsLoggingIn = false;
             return SteamClient.IsConnected;
         }
@@ -690,28 +730,64 @@ namespace FASTER.ViewModel
 
         private async Task DownloadForMultiple(IDownloadHandler downloadHandler, string targetDir)
         {
+            Logger.Log($"DownloadForMultiple: targetDir={targetDir}");
             if (targetDir == null)
+            {
+                Logger.Log("DownloadForMultiple: targetDir is null, aborting.");
                 return;
+            }
 
             if (!Directory.Exists(targetDir))
+            {
+                Logger.Log($"DownloadForMultiple: creating dir {targetDir}");
                 Directory.CreateDirectory(targetDir);
+            }
 
             tokenSource.Token.ThrowIfCancellationRequested();
             ulong downloadedSize = 0;
-            downloadHandler.FileVerified          += (_, args) => Parameters.Output += $"{(args.RequiresDownload ? $"\n    File verified : {args.ManifestFile.FileName} ({Functions.ParseFileSize(args.ManifestFile.TotalSize)})" : "")}";
-            downloadHandler.VerificationCompleted += (_, args) => Parameters.Output += $"\n    Verification completed, {args.QueuedFiles.Count} files queued for download. ({args.QueuedFiles.Sum(f => (double)f.TotalSize)} bytes)";
+            downloadHandler.FileVerified          += (_, args) =>
+            {
+                if (args.RequiresDownload)
+                {
+                    Logger.Log($"  File verified (needs download): {args.ManifestFile.FileName} ({Functions.ParseFileSize(args.ManifestFile.TotalSize)})");
+                    Parameters.Output += $"\n    File verified : {args.ManifestFile.FileName} ({Functions.ParseFileSize(args.ManifestFile.TotalSize)})";
+                }
+            };
+            downloadHandler.VerificationCompleted += (_, args) =>
+            {
+                Logger.Log($"  Verification completed: {args.QueuedFiles.Count} files queued ({args.QueuedFiles.Sum(f => (double)f.TotalSize)} bytes)");
+                Parameters.Output += $"\n    Verification completed, {args.QueuedFiles.Count} files queued for download. ({args.QueuedFiles.Sum(f => (double)f.TotalSize)} bytes)";
+            };
             downloadHandler.FileDownloaded        += (_, args) =>
-                                                     {
-                                                         downloadedSize    += args.TotalSize;
-                                                         Parameters.Output += $"\n    Progress {downloadHandler.TotalProgress * 100:00.00}% ({Functions.ParseFileSize(downloadedSize)} / {Functions.ParseFileSize(downloadHandler.TotalFileSize)})";
-                                                     };
-            downloadHandler.DownloadComplete      += (_, _) => Parameters.Output += "\n    Download completed";
+            {
+                downloadedSize    += args.TotalSize;
+                Logger.Log($"  File downloaded: {args.ManifestFile?.FileName}, progress {downloadHandler.TotalProgress * 100:00.00}% ({Functions.ParseFileSize(downloadedSize)}/{Functions.ParseFileSize(downloadHandler.TotalFileSize)})");
+                Parameters.Output += $"\n    Progress {downloadHandler.TotalProgress * 100:00.00}% ({Functions.ParseFileSize(downloadedSize)} / {Functions.ParseFileSize(downloadHandler.TotalFileSize)})";
+            };
+            downloadHandler.DownloadComplete      += (_, _) =>
+            {
+                Logger.Log("  DownloadComplete event fired.");
+                Parameters.Output += "\n    Download completed";
+            };
 
+            Logger.Log($"DownloadForMultiple: starting Task.Run (Setup/Verify/Download), totalFiles={downloadHandler.TotalFileCount}, totalSize={Functions.ParseFileSize(downloadHandler.TotalFileSize)}");
             Task downloadTask = Task.Run(async () =>
             {
-                await downloadHandler.SetupAsync(targetDir, file => true, tokenSource.Token);
-                await downloadHandler.VerifyAsync(tokenSource.Token);
-                await downloadHandler.DownloadAsync(tokenSource.Token);
+                try
+                {
+                    Logger.Log("  SetupAsync starting...");
+                    await downloadHandler.SetupAsync(targetDir, file => true, tokenSource.Token);
+                    Logger.Log("  SetupAsync done. VerifyAsync starting...");
+                    await downloadHandler.VerifyAsync(tokenSource.Token);
+                    Logger.Log("  VerifyAsync done. DownloadAsync starting...");
+                    await downloadHandler.DownloadAsync(tokenSource.Token);
+                    Logger.Log("  DownloadAsync done.");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"  ERROR inside download Task.Run: {ex.GetType().Name}: {ex.Message}\n  StackTrace: {ex.StackTrace}");
+                    throw;
+                }
             });
 
             Parameters.Output += "\n    OK.";
@@ -722,7 +798,6 @@ namespace FASTER.ViewModel
             Parameters.Progress = 0;
             while (!downloadTask.IsCompleted && !downloadTask.IsCanceled && !tokenSource.IsCancellationRequested)
             {
-
                 var delayTask = Task.Delay(500, tokenSource.Token);
                 await Task.WhenAny(delayTask, downloadTask);
 
@@ -732,6 +807,7 @@ namespace FASTER.ViewModel
 
             if (downloadTask.IsCanceled)
             {
+                Logger.Log("DownloadForMultiple: task was cancelled.");
                 Parameters.Output += "\n    Task Cancelled";
                 DownloadTasks.Remove(downloadTask);
                 await downloadHandler.DisposeAsync();
@@ -742,11 +818,18 @@ namespace FASTER.ViewModel
             { await downloadTask; }
             catch (TaskCanceledException)
             {
+                Logger.Log("DownloadForMultiple: TaskCanceledException caught on await.");
                 Parameters.Output += "\n    Task Cancelled";
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"DownloadForMultiple: exception on await downloadTask: {ex.GetType().Name}: {ex.Message}\n  StackTrace: {ex.StackTrace}");
                 throw;
             }
             finally
             {
+                Logger.Log("DownloadForMultiple: finalizing, disposing handler.");
                 DownloadTasks.Remove(downloadTask);
                 await downloadHandler.DisposeAsync();
                 downloadTask.Dispose();

--- a/FASTER/ViewModel/SteamUpdaterViewModel.cs
+++ b/FASTER/ViewModel/SteamUpdaterViewModel.cs
@@ -434,14 +434,13 @@ namespace FASTER.ViewModel
             {
                 await maxThread.WaitAsync();
 
-                _ = Task.Factory.StartNew(() =>
+                _ = Task.Factory.StartNew(async () =>
                 {
                     if (!Directory.Exists(mod.Path))
                         Directory.CreateDirectory(mod.Path);
 
                     if (tokenSource.Token.IsCancellationRequested)
                     {
-                        mod.Status = ArmaModStatus.NotComplete;
                         return;
                     }
                     Parameters.Output += $"\n   Starting {mod.WorkshopId}";
@@ -450,7 +449,7 @@ namespace FASTER.ViewModel
                     try
                     {
                         ManifestId manifestId = default;
-                        
+
                         if(mod.LocalLastUpdated > mod.SteamLastUpdated && mod.Size > 0)
                         {
                             mod.Status = ArmaModStatus.UpToDate;
@@ -461,16 +460,16 @@ namespace FASTER.ViewModel
                         if (!SteamClient.Credentials.IsAnonymous) //IS SYNC NEABLED
                         {
                             Parameters.Output += $"\n   Getting manifest for {mod.WorkshopId}";
-                            manifestId = SteamContentClient.GetPublishedFileDetailsAsync(mod.WorkshopId).Result.hcontent_file;
-                            Manifest manifest = SteamContentClient.GetManifestAsync(107410, 107410, manifestId).Result;
+                            manifestId = (await SteamContentClient.GetPublishedFileDetailsAsync(mod.WorkshopId)).hcontent_file;
+                            Manifest manifest = await SteamContentClient.GetManifestAsync(107410, 107410, manifestId);
                             Parameters.Output += $"\n   Manifest retrieved {mod.WorkshopId}";
                             SyncDeleteRemovedFiles(mod.Path, manifest);
                         }
 
                         Parameters.Output += $"\n    Attempting to start download of item {mod.WorkshopId}... ";
 
-                        var downloadHandler = SteamContentClient.GetPublishedFileDataAsync(mod.WorkshopId, manifestId, tokenSource.Token);
-                        DownloadForMultiple(downloadHandler.Result, mod.Path).Wait();
+                        var downloadHandler = await SteamContentClient.GetPublishedFileDataAsync(mod.WorkshopId, manifestId, tokenSource.Token);
+                        await DownloadForMultiple(downloadHandler, mod.Path);
 
                         mod.Status = ArmaModStatus.UpToDate;
                         var nx = DateTime.UnixEpoch;
@@ -494,7 +493,7 @@ namespace FASTER.ViewModel
 
                     Parameters.Output += $"\n    Download {mod.WorkshopId} completed, it took {sw.Elapsed.Minutes + sw.Elapsed.Hours*60}m {sw.Elapsed.Seconds}s {sw.Elapsed.Milliseconds}ms";
 
-                }, TaskCreationOptions.LongRunning).ContinueWith((_) =>
+                }, TaskCreationOptions.LongRunning).Unwrap().ContinueWith((_) =>
                 {
                     finished += 1;
                     Parameters.Output += $"\n   Thread {mod.WorkshopId} complete  ({finished} / {ml.Count})";
@@ -504,11 +503,16 @@ namespace FASTER.ViewModel
             }
 
             Parameters.Output += "\nAlmost there...";
-            await maxThread.WaitAsync();
-
+            try
+            {
+                await maxThread.WaitAsync();
+            }
+            finally
+            {
+                IsDlOverride = false;
+            }
 
             Parameters.Output += "\nMods updated !";
-            IsDlOverride = false;
             return UpdateState.Success;
         }
 
@@ -546,6 +550,7 @@ namespace FASTER.ViewModel
                 catch (Exception ex)
                 {
                     Parameters.Output += $"\nFailed! Error: {ex.Message}";
+                    var savedUsername = SteamClient?.Credentials.Username;
                     SteamClient.Shutdown();
                     SteamClient.Dispose();
                     SteamClient = null;
@@ -553,7 +558,7 @@ namespace FASTER.ViewModel
                     if (ex.GetBaseException() is SteamAuthenticationException)
                     {
                         Parameters.Output += "\nWarning: The logon may have failed due to expired sentry-data."
-                                             + $"\nIf you are sure that the provided username and password are correct, consider deleting the token file for the user \"{SteamClient?.Credentials.Username}\" in the sentries directory."
+                                             + $"\nIf you are sure that the provided username and password are correct, consider deleting the token file for the user \"{savedUsername}\" in the sentries directory."
                                              + $"{path}";
                     }
                     IsLoggingIn = false;

--- a/FASTER/Views/Mods.xaml
+++ b/FASTER/Views/Mods.xaml
@@ -51,6 +51,12 @@
             <Button ToolTip="Delete All"
                     Style="{StaticResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" Padding="7,5"
                     Content="{iconPacks:Modern Kind=Delete}" Click="DeleteAll_Click" RenderTransformOrigin="0.258,42.716" />
+            <Button ToolTip="Purge &amp; Reinstall All (deletes mod folders and marks all Steam mods for re-download)"
+                    Style="{StaticResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" Padding="7,5"
+                    Content="{iconPacks:Material Kind=Nuke}" Click="PurgeAndReinstallAll_Click" />
+            <Button ToolTip="Purge Unused Mods (removes mods not assigned to any server profile)"
+                    Style="{StaticResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" Padding="7,5"
+                    Content="{iconPacks:Material Kind=Broom}" Click="PurgeUnusedMods_Click" />
         </StackPanel>
         <Grid Grid.Row="0" Grid.Column="1">
             <Grid.Effect>
@@ -83,7 +89,12 @@
 					    <MenuItem.Icon>
 						    <iconPacks:PackIconMaterial Kind="Delete" Margin="5"/>
 					    </MenuItem.Icon>
-					</MenuItem>	
+					</MenuItem>
+                    <MenuItem Tag="PurgeAndReinstall" Header="Purge &amp; Reinstall" Click="PurgeAndReinstallSelected_Click">
+                        <MenuItem.Icon>
+                            <iconPacks:PackIconMaterial Kind="Nuke" Margin="5"/>
+                        </MenuItem.Icon>
+                    </MenuItem>
                 </ContextMenu>
             </DataGrid.ContextMenu>
             <DataGrid.Effect>

--- a/FASTER/Views/Mods.xaml.cs
+++ b/FASTER/Views/Mods.xaml.cs
@@ -72,9 +72,9 @@ namespace FASTER.Views
             await ((ModsViewModel)DataContext)?.OpenLauncherFile();
         }
 
-        private void CheckForUpdates_Click(object sender, RoutedEventArgs e)
+        private async void CheckForUpdates_Click(object sender, RoutedEventArgs e)
         {
-            ((ModsViewModel) DataContext)?.CheckForUpdates();
+            await ((ModsViewModel) DataContext)?.CheckForUpdates();
         }
 
         private void UpdateAll_Click(object sender, RoutedEventArgs e)
@@ -85,6 +85,21 @@ namespace FASTER.Views
 		private async void DeleteAll_Click(object sender, RoutedEventArgs e)
         {
             await ((ModsViewModel) DataContext)?.DeleteAllMods();
+        }
+
+        private async void PurgeAndReinstallAll_Click(object sender, RoutedEventArgs e)
+        {
+            await ((ModsViewModel) DataContext)?.PurgeAndReinstallAll();
+        }
+
+        private void PurgeAndReinstallSelected_Click(object sender, RoutedEventArgs e)
+        {
+            ((ModsViewModel) DataContext)?.PurgeAndReinstallSelectedMods();
+        }
+
+        private async void PurgeUnusedMods_Click(object sender, RoutedEventArgs e)
+        {
+            await ((ModsViewModel) DataContext)?.PurgeUnusedMods();
         }
     }
 }

--- a/FASTER/Views/Profile.xaml
+++ b/FASTER/Views/Profile.xaml
@@ -444,6 +444,7 @@
                                 <RowDefinition Height="auto"/>
                                 <RowDefinition Height="auto"/>
                                 <RowDefinition Height="auto"/>
+                                <RowDefinition Height="auto"/>
                             </Grid.RowDefinitions>
 
                             <mah:ToggleSwitch Content="Mission selector override" IsOn="{Binding Path=Profile.ServerCfg.MissionChecked}" Margin="5,0"/>
@@ -491,6 +492,7 @@
                                 <CheckBox Content="AutoSelect Mission" IsChecked="{Binding Path=Profile.ServerCfg.AutoSelectMission}" Margin="5" HorizontalAlignment="Left"/>
                                 <CheckBox Content="Random Order" IsChecked="{Binding Path=Profile.ServerCfg.RandomMissionOrder}" Margin="5" HorizontalAlignment="Right"/>
                             </Grid>
+                            <TextBox Grid.Row="5" Text="{Binding Path=Profile.ServerCfg.MissionHTTPDownloadBaseURL, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="missionHTTPDownloadBaseURL" Margin="5,3"/>
                         </Grid>
                     </GroupBox>
                     <GroupBox Grid.Column="1" Grid.Row="0" Header="Difficulty Settings" Margin="4, 0, 5, 0">
@@ -820,6 +822,23 @@
                                         <mah:NumericUpDown Grid.Row="2" Value="{Binding Path=Profile.ServerCfg.MotdInterval, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="Delay Between Messages" Margin="10,0,10,5" Minimum="0" HorizontalAlignment="Left"/>
                                     </Grid>
                                 </GroupBox>
+
+                                <!-- ANTIFLOOD TILE -->
+                                <Expander Header="AntiFlood Settings">
+                                    <Expander.Style>
+                                        <Style TargetType="Expander" BasedOn="{StaticResource MahApps.Styles.Expander}">
+                                            <Setter Property="Margin" Value="5"/>
+                                            <Setter Property="Background" Value="{StaticResource MahApps.Brushes.Window.Background}"></Setter>
+                                        </Style>
+                                    </Expander.Style>
+                                    <StackPanel>
+                                        <CheckBox IsChecked="{Binding Path=Profile.ServerCfg.AntiFloodEnabled}" Content="Enable AntiFlood" Margin="5,3"/>
+                                        <mah:NumericUpDown Value="{Binding Path=Profile.ServerCfg.AntiFloodCycleTime}" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="Cycle Time" Minimum="1" Margin="5"/>
+                                        <mah:NumericUpDown Value="{Binding Path=Profile.ServerCfg.AntiFloodCycleLimit}" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="Cycle Limit" Minimum="1" Margin="5"/>
+                                        <mah:NumericUpDown Value="{Binding Path=Profile.ServerCfg.AntiFloodCycleHardLimit}" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="Cycle Hard Limit" Minimum="1" Margin="5"/>
+                                        <CheckBox IsChecked="{Binding Path=Profile.ServerCfg.AntiFloodEnableKick}" Content="Enable Kick" Margin="5,3"/>
+                                    </StackPanel>
+                                </Expander>
                             </StackPanel>
                         </Grid>
                     </ScrollViewer>
@@ -860,8 +879,18 @@
                                 <RowDefinition Height="auto"/>
                                 <RowDefinition Height="10"/>
                                 <RowDefinition Height="auto"/>
+                                <RowDefinition Height="10"/>
+                                <RowDefinition Height="auto"/>
                                 <RowDefinition Height="40"/>
                                 <RowDefinition Height="auto"/>
+                                <RowDefinition Height="auto"/>
+                                <RowDefinition Height="10"/>
+                                <RowDefinition Height="auto"/>
+                                <RowDefinition Height="10"/>
+                                <RowDefinition Height="auto"/>
+                                <RowDefinition Height="10"/>
+                                <RowDefinition Height="auto"/>
+                                <RowDefinition Height="10"/>
                                 <RowDefinition Height="auto"/>
                                 <RowDefinition Height="20"/>
                                 <RowDefinition Height="auto"/>
@@ -882,12 +911,35 @@
                             <ComboBox Grid.Row="6" Grid.Column="1" SelectedItem="{Binding Path=Profile.BasicCfg.TerrainGrid, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.Watermark="Terrain Grid" mah:TextBoxHelper.UseFloatingWatermark="True" ItemsSource="{Binding TerrainGrids}" Margin="3"/>
                             <mah:NumericUpDown Grid.Row="6" Grid.Column="2" Value="{Binding Profile.BasicCfg.ViewDistance, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.Watermark="Server View Distance" mah:TextBoxHelper.UseFloatingWatermark="True" Minimum="0" Maximum="50000" Interval="1" Margin="3,3,3,3"/>
 
-                            <CheckBox Grid.Row="8" Grid.Column="0" Margin="3,5" IsChecked="{Binding Path=Profile.ServerCfg.MaxMemOverride, UpdateSourceTrigger=PropertyChanged}" Content="Force Maximum Memory"/>
-                            <CheckBox Grid.Row="8" Grid.Column="1" Margin="3,5" IsChecked="{Binding Path=Profile.EnableHyperThreading, UpdateSourceTrigger=PropertyChanged}" Content="Enable Hyper Threading"/>
-                            <CheckBox Grid.Row="8" Grid.Column="2" Margin="3,5" IsChecked="{Binding Path=Profile.ServerCfg.CpuCountOverride, UpdateSourceTrigger=PropertyChanged}" Content="Force CPU Count"/>
-                            <mah:NumericUpDown Grid.Row="9" Grid.Column="0" Value="{Binding Profile.ServerCfg.MaxMem, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding Path=Profile.ServerCfg.MaxMemOverride, Converter={StaticResource BoolToVis}}" mah:TextBoxHelper.Watermark="Maximum Memory (MB)" mah:TextBoxHelper.UseFloatingWatermark="True" Minimum="1024" Maximum="128000" Interval="1" Margin="3,3,3,-11"/>
-                            <mah:NumericUpDown Grid.Row="9" Grid.Column="2" Value="{Binding Profile.ServerCfg.CpuCount, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding Path=Profile.ServerCfg.CpuCountOverride, Converter={StaticResource BoolToVis}}" mah:TextBoxHelper.Watermark="CPU Core Count" mah:TextBoxHelper.UseFloatingWatermark="True" Minimum="1" Maximum="34" Interval="1" Margin="3,3,3,-11"/>
-                            <TextBox Text="{Binding Profile.ServerCfg.CommandLineParameters, UpdateSourceTrigger=PropertyChanged}" Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="3" Margin="3,5" mah:TextBoxHelper.Watermark="Command Line Arguments" mah:TextBoxHelper.UseFloatingWatermark="True"/>
+                            <ComboBox Grid.Row="8" Grid.Column="0" SelectedItem="{Binding Path=Profile.BasicCfg.Language, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.Watermark="Server Language" mah:TextBoxHelper.UseFloatingWatermark="True" ItemsSource="{Binding Languages}" Margin="3"/>
+
+                            <CheckBox Grid.Row="10" Grid.Column="0" Margin="3,5" IsChecked="{Binding Path=Profile.ServerCfg.MaxMemOverride, UpdateSourceTrigger=PropertyChanged}" Content="Force Maximum Memory"/>
+                            <CheckBox Grid.Row="10" Grid.Column="1" Margin="3,5" IsChecked="{Binding Path=Profile.EnableHyperThreading, UpdateSourceTrigger=PropertyChanged}" Content="Enable Hyper Threading"/>
+                            <CheckBox Grid.Row="10" Grid.Column="2" Margin="3,5" IsChecked="{Binding Path=Profile.ServerCfg.CpuCountOverride, UpdateSourceTrigger=PropertyChanged}" Content="Force CPU Count"/>
+                            <mah:NumericUpDown Grid.Row="11" Grid.Column="0" Value="{Binding Profile.ServerCfg.MaxMem, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding Path=Profile.ServerCfg.MaxMemOverride, Converter={StaticResource BoolToVis}}" mah:TextBoxHelper.Watermark="Maximum Memory (MB)" mah:TextBoxHelper.UseFloatingWatermark="True" Minimum="1024" Maximum="128000" Interval="1" Margin="3,3,3,-11"/>
+                            <mah:NumericUpDown Grid.Row="11" Grid.Column="2" Value="{Binding Profile.ServerCfg.CpuCount, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding Path=Profile.ServerCfg.CpuCountOverride, Converter={StaticResource BoolToVis}}" mah:TextBoxHelper.Watermark="CPU Core Count" mah:TextBoxHelper.UseFloatingWatermark="True" Minimum="1" Maximum="34" Interval="1" Margin="3,3,3,-11"/>
+                            <CheckBox Grid.Row="13" Grid.Column="0" Margin="3,5" IsChecked="{Binding Path=Profile.HugePages, UpdateSourceTrigger=PropertyChanged}" Content="-hugePages"/>
+                            <CheckBox Grid.Row="13" Grid.Column="1" Margin="3,5" IsChecked="{Binding Path=Profile.LoadMissionToMemory, UpdateSourceTrigger=PropertyChanged}" Content="-loadMissionToMemory"/>
+                            <CheckBox Grid.Row="13" Grid.Column="2" Margin="3,5" IsChecked="{Binding Path=Profile.EnableSteamLogs, UpdateSourceTrigger=PropertyChanged}" Content="-enableSteamLogs"/>
+                            <Grid Grid.Row="15" Grid.Column="0" Grid.ColumnSpan="2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition/>
+                                    <ColumnDefinition Width="auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Grid.Column="0" Text="{Binding Path=Profile.BePath, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="-bePath (BattlEye directory)" Margin="3,3,0,3"/>
+                                <Button Grid.Column="1" Content="{iconPacks:Material Kind=FolderOpen}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}" Height="auto" Margin="5,3,3,3" Style="{StaticResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" Padding="3" Click="SelectBePath"/>
+                            </Grid>
+                            <mah:NumericUpDown Grid.Row="15" Grid.Column="2" Value="{Binding Profile.ExThreads, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.Watermark="-exThreads (0=off)" mah:TextBoxHelper.UseFloatingWatermark="True" Minimum="0" Maximum="7" Interval="1" Margin="3"/>
+                            <Grid Grid.Row="17" Grid.Column="0" Grid.ColumnSpan="2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition/>
+                                    <ColumnDefinition Width="auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Grid.Column="0" Text="{Binding Path=Profile.KeysFolder, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.UseFloatingWatermark="True" mah:TextBoxHelper.Watermark="-keysFolder (Keys directory)" Margin="3,3,0,3"/>
+                                <Button Grid.Column="1" Content="{iconPacks:Material Kind=FolderOpen}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}" Height="auto" Margin="5,3,3,3" Style="{StaticResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" Padding="3" Click="SelectKeysFolder"/>
+                            </Grid>
+                            <mah:NumericUpDown Grid.Row="19" Grid.Column="0" Value="{Binding Profile.LimitFPS, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.Watermark="-limitFPS (0=off, max 200)" mah:TextBoxHelper.UseFloatingWatermark="True" Minimum="0" Maximum="200" Interval="1" Margin="3"/>
+                            <TextBox Text="{Binding Profile.ServerCfg.CommandLineParameters, UpdateSourceTrigger=PropertyChanged}" Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="3" Margin="3,5" mah:TextBoxHelper.Watermark="Command Line Arguments" mah:TextBoxHelper.UseFloatingWatermark="True"/>
                         </Grid>
                     </GroupBox>
                     <Grid Grid.Row="1">

--- a/FASTER/Views/Profile.xaml.cs
+++ b/FASTER/Views/Profile.xaml.cs
@@ -108,6 +108,16 @@ namespace FASTER.Views
             ((ProfileViewModel) DataContext)?.SelectServerFile();
         }
 
+        private void SelectBePath(object sender, RoutedEventArgs e)
+        {
+            ((ProfileViewModel) DataContext)?.SelectBePath();
+        }
+
+        private void SelectKeysFolder(object sender, RoutedEventArgs e)
+        {
+            ((ProfileViewModel) DataContext)?.SelectKeysFolder();
+        }
+
         private void OpenProfileLocation(object sender, RoutedEventArgs e)
         {
             ((ProfileViewModel) DataContext)?.OpenProfileLocation();

--- a/FASTER/Views/Settings.xaml
+++ b/FASTER/Views/Settings.xaml
@@ -39,6 +39,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
                 <StackPanel Grid.ColumnSpan="10">
@@ -50,7 +51,17 @@
                 <CheckBox Name="IModUpdatesOnLaunch" Grid.ColumnSpan="2" Grid.Row="1" Grid.Column="0" Content="Check for Steam Mod Updates on Launch" Click="IModUpdatesOnLaunch_Checked" IsChecked="True" Margin="10,0,10,10"/>
                 <CheckBox Name="IAppUpdatesOnLaunch" Grid.ColumnSpan="2" Grid.Row="2" Grid.Column="0" Content="Auto Update FASTER on Launch" Click="IAppUpdatesOnLaunch_Checked" IsChecked="False" Margin="10,0,10,10"/>
 
-                <Grid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="10,20">
+                <Grid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="4" Margin="10,2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                    <CheckBox Name="IEnableDebugLog" Grid.Column="0" Content="Enable Debug Logging" Click="IEnableDebugLog_Checked" IsChecked="False" Margin="0,0,20,0" VerticalAlignment="Center"/>
+                    <Button Name="IOpenLogFile" Grid.Column="1" Content="Open Log File" Click="IOpenLogFile_Click" Style="{DynamicResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" Padding="8,2" Height="24"/>
+                </Grid>
+
+                <Grid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Margin="10,20">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition/>
@@ -59,7 +70,7 @@
                     <Slider Name="Slider" Grid.Column="1" IsSnapToTickEnabled="True" Minimum="1" Maximum="50" SmallChange="1" LargeChange="0" ValueChanged="RangeBase_OnValueChanged"/>
                 </Grid>
 
-                <Grid Grid.Row="4" Grid.ColumnSpan="2" Grid.Column="0" Margin="5,10">
+                <Grid Grid.Row="5" Grid.ColumnSpan="2" Grid.Column="0" Margin="5,10">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition />
                         <ColumnDefinition Width="auto"/>
@@ -68,7 +79,7 @@
                     <Button Grid.Column="1" Name="IAPIKeyButton" Content="{iconPacks:Material Kind=Web}" Style="{DynamicResource MahApps.Styles.Button.MetroSquare.Accent}" BorderThickness="0" VerticalAlignment="Stretch" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}" Margin="5" Padding="2" Click="APIKeyButton_Click"/>
                 </Grid>
 
-                <Grid Grid.Row="5" Grid.ColumnSpan="4" Grid.Column="0">
+                <Grid Grid.Row="6" Grid.ColumnSpan="4" Grid.Column="0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition/>
                         <ColumnDefinition/>

--- a/FASTER/Views/Settings.xaml.cs
+++ b/FASTER/Views/Settings.xaml.cs
@@ -7,6 +7,8 @@ using ControlzEx.Theming;
 using FASTER.Models;
 
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -129,6 +131,7 @@ namespace FASTER.Views
         {
             IModUpdatesOnLaunch.IsChecked = Properties.Settings.Default?.checkForModUpdates;
             IAppUpdatesOnLaunch.IsChecked = Properties.Settings.Default?.checkForAppUpdates;
+            IEnableDebugLog.IsChecked = Properties.Settings.Default?.enableDebugLog;
             IAPIKeyBox.Text = Properties.Settings.Default?.SteamAPIKey ?? string.Empty;
             Slider.Value = Properties.Settings.Default.CliWorkers;
             NumericUpDown.Value = Slider.Value;
@@ -146,6 +149,22 @@ namespace FASTER.Views
             Properties.Settings.Default.Save();
         }
 
+        private void IEnableDebugLog_Checked(object sender, RoutedEventArgs e)
+        {
+            Properties.Settings.Default.enableDebugLog = IEnableDebugLog.IsChecked ?? false;
+            Properties.Settings.Default.Save();
+            Logger.Log("Debug logging enabled.");
+        }
+
+        private void IOpenLogFile_Click(object sender, RoutedEventArgs e)
+        {
+            var path = Logger.LogFilePath;
+            if (File.Exists(path))
+                Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+            else
+                MainWindow.Instance.DisplayMessage($"No log file found at:\n{path}");
+        }
+
         private void IUpdateApp_OnClick(object sender, RoutedEventArgs e)
         { AutoUpdater.Start("https://raw.githubusercontent.com/Foxlider/FASTER/master/FASTER_Version.xml"); }
 
@@ -158,6 +177,7 @@ namespace FASTER.Views
                 Properties.Settings.Default.SteamAPIKey = IAPIKeyBox.Text;
             Properties.Settings.Default.checkForAppUpdates = IAppUpdatesOnLaunch.IsChecked ?? true;
             Properties.Settings.Default.checkForModUpdates = IModUpdatesOnLaunch.IsChecked ?? true;
+            Properties.Settings.Default.enableDebugLog = IEnableDebugLog.IsChecked ?? false;
             Properties.Settings.Default.Save();
         }
 

--- a/FASTER_Version.xml
+++ b/FASTER_Version.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <item>
-  <version>1.9.7.2</version>
+  <version>1.9.7.3</version>
   <url>https://github.com/Foxlider/FASTER/releases/latest/download/Release_x64.zip</url>
   <changelog>https://github.com/Foxlider/FASTER/releases</changelog>
   <mandatory>true</mandatory>

--- a/FASTER_Version.xml
+++ b/FASTER_Version.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <item>
-  <version>1.9.7.3</version>
-  <url>https://github.com/Foxlider/FASTER/releases/latest/download/Release_x64.zip</url>
-  <changelog>https://github.com/Foxlider/FASTER/releases</changelog>
+  <version>2.0.0.0</version>
+  <url>https://github.com/diaverso/FASTER/releases/latest/download/Release_x64.zip</url>
+  <changelog>https://github.com/diaverso/FASTER/releases</changelog>
   <mandatory>true</mandatory>
 </item>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "rollForward": "latestFeature",
+        "rollForward": "latestMajor",
         "version": "8.0.0"
     }
 }


### PR DESCRIPTION
## Summary

This PR resolves all open GitHub issues, integrates all open pull requests, and adds several requested features. Version bumped to **2.0.0.0**.

---

## Bug Fixes

| Issue | Description | File(s) |
|-------|-------------|---------|
| #255 | `forcedDifficulty` was not quoted in server.cfg output | `ServerCfg.cs` |
| #184 / #221 | `RaisePropertyChanged` called with literal strings instead of `nameof()` across ServerCfg, BasicCfg and related models | `ServerCfg.cs`, `BasicCfg.cs` |
| #251 / #115 | Cloning a profile reset `MaxMsgSend` to 256 — `PerfPreset` getter always returns `"Custom"` so JSON deserialization triggered the setter; fixed with `[JsonIgnore]` | `BasicCfg.cs` |
| #254 | `LinkMod` / `DeleteLink` called `Directory.Delete(path, true)` on symlinks, destroying the source folder instead of just the link | `DeploymentViewModel.cs` |
| #131 | `DeployAll` did not check whether the install path exists before trying to create symlinks | `DeploymentViewModel.cs` |
| #242 | `mod.Status` was incorrectly reset to `NotComplete` in the cancellation path before any download started | `SteamUpdaterViewModel.cs` |
| #259 | `Task.Factory.StartNew(async () => ...)` returned `Task<Task>`; missing `.Unwrap()` caused `ContinueWith` to fire immediately, not after async work completed | `SteamUpdaterViewModel.cs` |
| #238 | `NullReferenceException` when `SteamClient` was set to null before the error message string was evaluated | `SteamUpdaterViewModel.cs` |
| #167 | After 3 failed retries in `UpdateInfos()`, no user-visible error was shown; added one-time warning for bad Steam API Key | `ArmaMod.cs`, `SteamWebApi.cs` |

---

## Pull Requests Integrated

| PR | Description | File(s) |
|----|-------------|---------|
| #246 | Output `class AdvancedOptions { }` block in server.cfg | `ServerCfg.cs` |
| #230 | Configurable `language` setting in BasicCfg with dropdown in Profile UI | `BasicCfg.cs`, `ProfileViewModel.cs`, `Profile.xaml` |
| #231 | New command-line parameters: HugePages, BePath, ExThreads, LoadMissionToMemory, LimitFPS, EnableSteamLogs | `ServerProfile.cs`, `ProfileViewModel.cs`, `Profile.xaml` |
| #198 | Purge and Reinstall: delete mod folder and mark for re-download (single, selected, all) | `ModsViewModel.cs`, `Mods.xaml` |
| #258 | `CheckForUpdates` made async with 300ms delay between mods to avoid rate limiting | `ModsViewModel.cs`, `Mods.xaml` |
| #239 | GitHub Actions workflows missing `DOTNET_VERSION` env var | `.github/workflows/` |

---

## New Features

| Issue | Description | File(s) |
|-------|-------------|---------|
| #217 | AntiFlood settings block in server.cfg (enabled, cycle time, cycle limit, hard limit, kick) | `ServerCfg.cs`, `Profile.xaml` |
| #229 | `missionHTTPDownloadBaseURL` setting in server.cfg | `ServerCfg.cs`, `Profile.xaml` |
| #241 | `-keysFolder` command-line parameter with folder browser button | `ServerProfile.cs`, `ProfileViewModel.cs`, `Profile.xaml` |
| #216 | Profile reordering via ▲/▼ buttons in the side panel | `MainWindow.xaml.cs`, `ServerProfile.cs` |
| #209 | Purge Unused Mods: cross-references all profiles and deletes mods not used by any profile | `ModsViewModel.cs`, `Mods.xaml` |

---

## Additional Improvements

- **Purge and Reinstall All**: reworked to delete all folders inside the Mod Staging Directory and immediately launch Update All
- **Debug Logging**: new toggle in Settings that writes timestamped entries to `%AppData%\FASTER\faster.log`; includes an "Open Log File" button; covers CheckForUpdates, PurgeAndReinstall, DeployAll, and LinkMod
- **GitHub Actions**: added standalone `build.yml` workflow; fixed `release.yml` trigger and permissions; replaced unmaintained `andelf/nightly-release` with `softprops/action-gh-release@v2`
- **Version**: bumped to 2.0.0.0

---
